### PR TITLE
Minor sample cleanup.

### DIFF
--- a/samples/image_viewer/main.go
+++ b/samples/image_viewer/main.go
@@ -16,8 +16,8 @@ import (
 	gomath "math"
 )
 
-var data = flag.String("data", "data", "path to data")
-var file = flag.String("file", "file", "path to file")
+var data = flag.String("data", "", "path to data")
+var file = flag.String("file", "", "path to file")
 var width = flag.Int("width", 0, "width of the image")
 var height = flag.Int("height", 0, "height of the image")
 var imageType = flag.String("type", "rgba", "The type of the image (rgba or depth)")

--- a/samples/polyedit/main.go
+++ b/samples/polyedit/main.go
@@ -7,13 +7,14 @@ package main
 import (
 	"flag"
 	"fmt"
+
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/themes/dark"
 )
 
-var data = flag.String("data", "data", "path to data")
+var data = flag.String("data", "", "path to data")
 
 func vertexAt(p gxui.Polygon, at math.Point) int {
 	for i, v := range p {

--- a/samples/polygon/main.go
+++ b/samples/polygon/main.go
@@ -6,13 +6,14 @@ package main
 
 import (
 	"flag"
+
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/themes/dark"
 )
 
-var data = flag.String("data", "data", "path to data")
+var data = flag.String("data", "", "path to data")
 
 func buildStar(theme gxui.Theme, center math.Point, radius, rotation float32, points int) gxui.Image {
 	p := make(gxui.Polygon, points*2)

--- a/samples/progress_bar/main.go
+++ b/samples/progress_bar/main.go
@@ -6,14 +6,15 @@ package main
 
 import (
 	"flag"
+	"time"
+
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/themes/dark"
-	"time"
 )
 
-var data = flag.String("data", "data", "path to data")
+var data = flag.String("data", "", "path to data")
 
 func appMain(driver gxui.Driver) {
 	theme := dark.CreateTheme(driver)
@@ -35,12 +36,13 @@ func appMain(driver gxui.Driver) {
 	window.OnClose(driver.Terminate)
 
 	progress := 0
+	pause := time.Millisecond * 500
 	var timer *time.Timer
-	timer = time.AfterFunc(time.Millisecond*500, func() {
+	timer = time.AfterFunc(pause, func() {
 		driver.Events() <- func() {
 			progress = (progress + 3) % progressBar.Target()
 			progressBar.SetProgress(progress)
-			timer.Reset(time.Millisecond * 500)
+			timer.Reset(pause)
 		}
 	})
 


### PR DESCRIPTION
Make default values for string flags "" instead of the name of the variable.

Separate github imports from standard library imports.

Make a variable for a time.Duration that was used more than once.