### PR TITLE
AxisItemSize may become zero

### DIFF
--- a/mixins/list.go
+++ b/mixins/list.go
@@ -246,6 +246,9 @@ func (l *List) VisibleItemRange(includePartiallyVisible bool) (startIndex, endIn
 	s := l.outer.Bounds().Size()
 	p := l.outer.Padding()
 	majorAxisItemSize := l.MajorAxisItemSize()
+	if majorAxisItemSize == 0 {
+		return 0, 0
+	}
 	startIndex = l.scrollOffset
 	if !includePartiallyVisible {
 		startIndex += majorAxisItemSize - 1


### PR DESCRIPTION
https://github.com/mattn/gxuitter

This is twitter client written in gxui. Currently work in progress.
See this part
https://github.com/mattn/gxuitter/blob/master/main.go#L331

When calling SetItemSizeAsLargest, AxisItemSize may become zero. So make devide by zero.
