### PR TITLE
gxui: use gxfont.Default, remove loading by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,25 +37,10 @@ If you add ```GOPATH/bin``` to your PATH, you can simply type the name of a samp
 
 Fonts
 ---
-Many of the samples require a font to render text. The dark theme (and currently the only theme) uses `Arial.ttf`.
-GXUI will try to locate fonts in the following places from top to bottom:
+Many of the samples require a font to render text. The dark theme (and currently the only theme) uses `Roboto`.
+This is built into the gxfont package.
 
- * [Windows](https://github.com/google/gxui/blob/master/drivers/gl/platform/windows_constants.go#L21)
-  * The directory specified with the command line argument `--data` (default is CWD)
-  * The windows font directory.
-
- * [OSX](https://github.com/google/gxui/blob/master/drivers/gl/platform/osx_constants.go#L12)
-  * The directory specified with the command line argument `--data` (default is CWD)
-  * `/Library/Fonts/`
-  * `/System/Library/Fonts/`
-
- * [Linux](https://github.com/google/gxui/blob/master/drivers/gl/platform/linux_constants.go#L12)
-  * The directory specified with the command line argument `--data` (default is CWD)
-  * `/usr/share/fonts`
-  * `/usr/local/share/fonts`
-  * `~/.fonts`
-
-Note: We are aware that Arial does not come with certain operating systems, and are looking to bundle a font with GXUI.
+Make sure to mention this font in any notices file distributed with your application.
 
 Contributing
 ---

--- a/driver.go
+++ b/driver.go
@@ -5,8 +5,9 @@
 package gxui
 
 import (
-	"github.com/google/gxui/math"
 	"image"
+
+	"github.com/google/gxui/math"
 )
 
 type Driver interface {
@@ -18,7 +19,10 @@ type Driver interface {
 	Terminate()
 	SetClipboard(str string)
 	GetClipboard() (string, error)
-	LoadFont(name string, size int) (Font, error)
+
+	// CreateFont loads a font from the provided TrueType bytes.
+	CreateFont(data []byte, size int) (Font, error)
+
 	CreateViewport(width, height int, name string) Viewport
 	CreateCanvas(math.Size) Canvas
 	CreateTexture(img image.Image, pixelsPerDip float32) Texture

--- a/drivers/gl/driver.go
+++ b/drivers/gl/driver.go
@@ -6,15 +6,11 @@ package gl
 
 import (
 	"container/list"
-	"fmt"
 	"image"
-	"io/ioutil"
-	"path/filepath"
 	"runtime"
 
 	"github.com/go-gl/glfw/v3.1/glfw"
 	"github.com/google/gxui"
-	"github.com/google/gxui/drivers/gl/platform"
 	"github.com/google/gxui/math"
 )
 
@@ -138,19 +134,8 @@ func (d *Driver) GetClipboard() (str string, err error) {
 	return
 }
 
-func (d *Driver) LoadFont(name string, size int) (gxui.Font, error) {
-	// Try the data path first.
-	f, err := ioutil.ReadFile(filepath.Join(d.dataPath, name))
-	if err == nil {
-		return CreateFont(name, f, size)
-	}
-	// No luck. Search the OS font directories next...
-	for _, path := range platform.FontPaths {
-		if f, err := ioutil.ReadFile(filepath.Join(path, name)); err == nil {
-			return CreateFont(name, f, size)
-		}
-	}
-	return nil, fmt.Errorf("Unable to find font '%s'", name)
+func (d *Driver) CreateFont(data []byte, size int) (gxui.Font, error) {
+	return createFont(data, size)
 }
 
 func (d *Driver) CreateViewport(width, height int, name string) gxui.Viewport {

--- a/drivers/gl/font.go
+++ b/drivers/gl/font.go
@@ -20,7 +20,6 @@ type Quad struct {
 }
 
 type Font struct {
-	name             string
 	size             int
 	scale            int32
 	glyphMaxSizeDips math.Size
@@ -31,7 +30,7 @@ type Font struct {
 	quads            []Quad // Reused each call to Draw()
 }
 
-func CreateFont(name string, data []byte, size int) (*Font, error) {
+func createFont(data []byte, size int) (*Font, error) {
 	ttf, err := truetype.Parse(data)
 	if err != nil {
 		return nil, err
@@ -46,7 +45,6 @@ func CreateFont(name string, data []byte, size int) (*Font, error) {
 	ascentDips := int(bounds.YMax >> 6)
 
 	return &Font{
-		name:             name,
 		size:             size,
 		scale:            scale,
 		glyphMaxSizeDips: glyphMaxSizeDips,
@@ -161,10 +159,6 @@ func (f *Font) DrawRunes(ctx *Context, runes []rune, col gxui.Color, points []ma
 		tc := ctx.GetOrCreateTextureContext(texture)
 		ctx.Blitter.BlitGlyph(ctx, tc, col, srcRect, dstRect, ds)
 	}
-}
-
-func (f *Font) Name() string {
-	return f.name
 }
 
 func (f *Font) Size() int {

--- a/drivers/gl/platform/linux_constants.go
+++ b/drivers/gl/platform/linux_constants.go
@@ -7,10 +7,3 @@
 package platform
 
 const ScrollSpeed = 20.0
-
-// Paths to try when a font is not found in the local data directory
-var FontPaths = []string{
-	"/usr/share/fonts",
-	"/usr/local/share/fonts",
-	"~/.fonts",
-}

--- a/drivers/gl/platform/osx_constants.go
+++ b/drivers/gl/platform/osx_constants.go
@@ -7,9 +7,3 @@
 package platform
 
 const ScrollSpeed = 4.0
-
-// Paths to try when a font is not found in the local data directory
-var FontPaths = []string{
-	"/Library/Fonts/",
-	"/System/Library/Fonts/",
-}

--- a/drivers/gl/platform/windows_constants.go
+++ b/drivers/gl/platform/windows_constants.go
@@ -6,25 +6,4 @@
 
 package platform
 
-// #cgo LDFLAGS: -lShell32
-// #include <Shlobj.h>
-//
-// void getWindowsFontDirectory(char* path) {
-//   SHGetFolderPath(0, CSIDL_FONTS, 0, 0, path);
-// }
-import "C"
-
 const ScrollSpeed = 20.0
-
-// Paths to try when a font is not found in the local data directory
-var FontPaths = []string{
-	getWindowsFontDirectory(),
-}
-
-const max_path = 260
-
-func getWindowsFontDirectory() string {
-	buf := make([]C.char, max_path)
-	C.getWindowsFontDirectory(&buf[0])
-	return C.GoString(&buf[0])
-}

--- a/font.go
+++ b/font.go
@@ -10,7 +10,6 @@ import (
 
 type Font interface {
 	LoadGlyphs(first, last rune)
-	Name() string
 	Size() int
 	GlyphMaxSize() math.Size
 	Measure(string) math.Size

--- a/themes/dark/theme.go
+++ b/themes/dark/theme.go
@@ -8,9 +8,8 @@ import (
 	"fmt"
 
 	"github.com/google/gxui"
+	"github.com/google/gxui/gxfont"
 )
-
-const defaultFontName = "Arial.ttf"
 
 type Theme struct {
 	driver      gxui.Driver
@@ -44,7 +43,7 @@ type Theme struct {
 }
 
 func CreateTheme(driver gxui.Driver) gxui.Theme {
-	defaultFont, err := driver.LoadFont(defaultFontName, 12)
+	defaultFont, err := driver.CreateFont(gxfont.Default, 12)
 	if err == nil {
 		defaultFont.LoadGlyphs(32, 126)
 	} else {


### PR DESCRIPTION
This leaves the discovery and bundling of fonts up to the user's
application. A default is provided, built into their binary with the
default theme (meaning a single binary can still be distributed).

The idea underlying this change is GXUI strives to be system independent.
Leave dependent things like finding fonts up to applications that
understand their systems.

/cc @ben-clayton 