### PR TITLE
Cleanup and simplify the Adapter interface

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -9,15 +9,38 @@ import (
 )
 
 // AdapterItem is a user defined type that can be used to uniquely identify a
-// single item in an adapter. The type must support equality.
+// single item in an adapter. The type must support equality and be hashable.
 type AdapterItem interface{}
 
+// Adapter is an interface used to visualize a set of items.
+// Users of the Adapter should presume the data is unchanged until the
+// OnDataChanged or OnDataReplaced events are fired.
 type Adapter interface {
-	ItemSize(theme Theme) math.Size
+	// Count returns the number of items represented by this adapter.
 	Count() int
+
+	// ItemAt returns the AdapterItem for the item at index i. It is important
+	// for the Adapter to return consistent AdapterItems for the same data item,
+	// so that selections can be persisted, or re-ordering animations can be
+	// played.
+	// The AdapterItem returned must be equality-unique across all indices.
 	ItemAt(index int) AdapterItem
+
+	// ItemIndex returns the index of item.
 	ItemIndex(item AdapterItem) int
+
+	// Size returns the size that each of the item's controls will be displayed
+	// at for the given theme.
+	Size(Theme) math.Size
+
+	// Create returns a Control visualizing the item at the specified index.
 	Create(theme Theme, index int) Control
-	OnDataChanged(func()) EventSubscription
-	OnDataReplaced(func()) EventSubscription
+
+	// OnDataChanged registers f to be called when there is a partial change in
+	// the items of the adapter.
+	OnDataChanged(f func()) EventSubscription
+
+	// OnDataReplaced registers f to be called when there is a complete
+	// replacement of items in the adapter.
+	OnDataReplaced(f func()) EventSubscription
 }

--- a/adapter.go
+++ b/adapter.go
@@ -8,17 +8,15 @@ import (
 	"github.com/google/gxui/math"
 )
 
-const InvalidAdapterItemId AdapterItemId = 0xFFFFFFFFFFFFFFFF
-
-type AdapterItemId uint64
-
-func (i AdapterItemId) IsValid() bool { return i != InvalidAdapterItemId }
+// AdapterItem is a user defined type that can be used to uniquely identify a
+// single item in an adapter. The type must support equality.
+type AdapterItem interface{}
 
 type Adapter interface {
 	ItemSize(theme Theme) math.Size
 	Count() int
-	ItemId(index int) AdapterItemId
-	ItemIndex(id AdapterItemId) int
+	ItemAt(index int) AdapterItem
+	ItemIndex(item AdapterItem) int
 	Create(theme Theme, index int) Control
 	OnDataChanged(func()) EventSubscription
 	OnDataReplaced(func()) EventSubscription

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -22,18 +22,18 @@ type DefaultAdapter struct {
 	AdapterBase
 	items       reflect.Value
 	itemToIndex map[AdapterItem]int
-	itemSize    math.Size
+	size        math.Size
 	styleLabel  func(Theme, Label)
 }
 
 func CreateDefaultAdapter() *DefaultAdapter {
 	l := &DefaultAdapter{
-		itemSize: math.Size{W: 200, H: 16},
+		size: math.Size{W: 200, H: 16},
 	}
 	return l
 }
 
-func (a *DefaultAdapter) SetItemSizeAsLargest(theme Theme) {
+func (a *DefaultAdapter) SetSizeAsLargest(theme Theme) {
 	s := math.Size{}
 	font := theme.DefaultFont()
 	for i := 0; i < a.Count(); i++ {
@@ -48,12 +48,7 @@ func (a *DefaultAdapter) SetItemSizeAsLargest(theme Theme) {
 			s = s.Max(font.Measure(str))
 		}
 	}
-	a.SetItemSize(s)
-}
-
-func (a *DefaultAdapter) SetItemSize(s math.Size) {
-	a.itemSize = s
-	a.DataChanged()
+	a.SetSize(s)
 }
 
 func (a *DefaultAdapter) SetStyleLabel(f func(Theme, Label)) {
@@ -77,8 +72,13 @@ func (a *DefaultAdapter) ItemIndex(item AdapterItem) int {
 	return a.itemToIndex[item]
 }
 
-func (a *DefaultAdapter) ItemSize(theme Theme) math.Size {
-	return a.itemSize
+func (a *DefaultAdapter) Size(theme Theme) math.Size {
+	return a.size
+}
+
+func (a *DefaultAdapter) SetSize(s math.Size) {
+	a.size = s
+	a.DataChanged()
 }
 
 func (a *DefaultAdapter) Create(theme Theme, index int) Control {

--- a/drop_down_list.go
+++ b/drop_down_list.go
@@ -15,9 +15,9 @@ type DropDownList interface {
 	SetBorderPen(Pen)
 	BackgroundBrush() Brush
 	SetBackgroundBrush(Brush)
-	Selected() AdapterItemId
-	Select(AdapterItemId)
-	OnSelectionChanged(func(AdapterItemId)) EventSubscription
+	Selected() AdapterItem
+	Select(AdapterItem)
+	OnSelectionChanged(func(AdapterItem)) EventSubscription
 	OnShowList(func()) EventSubscription
 	OnHideList(func()) EventSubscription
 }

--- a/filtered_list_adapter.go
+++ b/filtered_list_adapter.go
@@ -20,7 +20,7 @@ type FilteredListAdapter struct {
 }
 
 func (a *FilteredListAdapter) SetItems(items []FilteredListItem) {
-	// Clone, as we can mutate the order
+	// Clone, as the order can be mutated
 	a.items = append([]FilteredListItem{}, items...)
 	a.DefaultAdapter.SetItems(a.items)
 }

--- a/filtered_list_adapter.go
+++ b/filtered_list_adapter.go
@@ -5,7 +5,6 @@
 package gxui
 
 import (
-	"github.com/google/gxui/math"
 	"sort"
 	"strings"
 )
@@ -16,14 +15,46 @@ type FilteredListItem struct {
 }
 
 type FilteredListAdapter struct {
-	AdapterBase
+	DefaultAdapter
+	items []FilteredListItem
+}
+
+func (a *FilteredListAdapter) SetItems(items []FilteredListItem) {
+	// Clone, as we can mutate the order
+	a.items = append([]FilteredListItem{}, items...)
+	a.DefaultAdapter.SetItems(a.items)
+}
+
+func (a *FilteredListAdapter) Sort(partial string) {
+	partialLower := strings.ToLower(partial)
+	sorter := flaSorter{items: a.items, scores: make([]int, len(a.items))}
+	for i, s := range a.items {
+		sorter.scores[i] = flaScore(s.Name, strings.ToLower(s.Name), partial, partialLower)
+	}
+	sort.Sort(sorter)
+	a.DefaultAdapter.SetItems(a.items)
+}
+
+type flaSorter struct {
 	items  []FilteredListItem
-	order  []int
-	rorder []int
 	scores []int
 }
 
-func (s *FilteredListAdapter) score(str, strLower, partial, partialLower string) int {
+func (s flaSorter) Len() int {
+	return len(s.items)
+}
+
+func (s flaSorter) Less(i, j int) bool {
+	return s.scores[i] > s.scores[j]
+}
+
+func (s flaSorter) Swap(i, j int) {
+	items, scores := s.items, s.scores
+	items[i], items[j] = items[j], items[i]
+	scores[i], scores[j] = scores[j], scores[i]
+}
+
+func flaScore(str, strLower, partial, partialLower string) int {
 	l := len(partial)
 	for i := l; i > 0; i-- {
 		c := 0
@@ -34,80 +65,8 @@ func (s *FilteredListAdapter) score(str, strLower, partial, partialLower string)
 		}
 
 		if c > 0 {
-			return c + s.score(str, strLower, partial[i:], partialLower[i:])
+			return c + flaScore(str, strLower, partial[i:], partialLower[i:])
 		}
 	}
 	return 0
-}
-
-func (a *FilteredListAdapter) SetItems(items []FilteredListItem) {
-	a.items = items
-	a.order = make([]int, len(items))
-	a.rorder = make([]int, len(items))
-	a.scores = make([]int, len(items))
-	for i, _ := range a.order {
-		a.order[i] = i
-		a.rorder[i] = i
-	}
-	a.onDataReplaced.Fire()
-}
-
-func (a *FilteredListAdapter) Item(id AdapterItemId) FilteredListItem {
-	return a.items[id]
-}
-
-func (a *FilteredListAdapter) Sort(partial string) {
-	for i, _ := range a.order {
-		a.order[i] = i
-	}
-	partialLower := strings.ToLower(partial)
-	for i, s := range a.items {
-		a.scores[i] = a.score(s.Name, strings.ToLower(s.Name), partial, partialLower)
-	}
-	sort.Sort(a)
-	for i, j := range a.order {
-		a.rorder[j] = i
-	}
-	a.DataChanged()
-}
-
-// sort.Interface compliance
-func (a *FilteredListAdapter) Len() int {
-	return len(a.items)
-}
-
-func (a *FilteredListAdapter) Less(i, j int) bool {
-	return a.scores[a.order[i]] > a.scores[a.order[j]]
-}
-
-func (a *FilteredListAdapter) Swap(i, j int) {
-	t := a.order[i]
-	a.order[i] = a.order[j]
-	a.order[j] = t
-}
-
-// Adapter compliance
-func (a *FilteredListAdapter) ItemSize(theme Theme) math.Size {
-	return math.Size{W: 200, H: 16}
-}
-
-func (a *FilteredListAdapter) Count() int {
-	return len(a.items)
-}
-
-func (a *FilteredListAdapter) ItemId(index int) AdapterItemId {
-	return AdapterItemId(a.order[index])
-}
-
-func (a *FilteredListAdapter) ItemIndex(id AdapterItemId) int {
-	return a.rorder[id]
-}
-
-func (a *FilteredListAdapter) Create(theme Theme, index int) Control {
-	item := a.Item(a.ItemId(index))
-	l := theme.CreateLabel()
-	l.SetMargin(math.ZeroSpacing)
-	l.SetMultiline(false)
-	l.SetText(item.Name)
-	return l
 }

--- a/filtered_list_adapter_test.go
+++ b/filtered_list_adapter_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func calcScore(str, partial string) int {
-	a := FilteredListAdapter{}
-	return a.score(str, strings.ToLower(str), partial, strings.ToLower(partial))
+	return flaScore(str, strings.ToLower(str), partial, strings.ToLower(partial))
 }
 
 func TestFilteredListAdapterScore(t *testing.T) {

--- a/list.go
+++ b/list.go
@@ -15,11 +15,11 @@ type List interface {
 	SetBorderPen(Pen)
 	BackgroundBrush() Brush
 	SetBackgroundBrush(Brush)
-	ScrollTo(AdapterItemId)
-	IsItemVisible(AdapterItemId) bool
-	Item(AdapterItemId) Control
-	Selected() AdapterItemId
-	Select(AdapterItemId)
-	OnSelectionChanged(func(AdapterItemId)) EventSubscription
-	OnItemClicked(func(MouseEvent, AdapterItemId)) EventSubscription
+	ScrollTo(AdapterItem)
+	IsItemVisible(AdapterItem) bool
+	ItemControl(AdapterItem) Control
+	Selected() AdapterItem
+	Select(AdapterItem)
+	OnSelectionChanged(func(AdapterItem)) EventSubscription
+	OnItemClicked(func(MouseEvent, AdapterItem)) EventSubscription
 }

--- a/mixins/code_editor.go
+++ b/mixins/code_editor.go
@@ -128,7 +128,7 @@ func (t *CodeEditor) ShowSuggestionList() {
 	target := line.PositionAt(caret).Add(lineOffset)
 	cs := t.suggestionList.DesiredSize(math.ZeroSize, bounds.Size())
 	t.suggestionList.Layout(cs.Rect().Offset(target).Intersect(bounds))
-	t.suggestionList.Select(t.suggestionList.Adapter().ItemId(0))
+	t.suggestionList.Select(t.suggestionList.Adapter().ItemAt(0))
 	t.suggestionList.SetVisible(true)
 }
 
@@ -137,8 +137,7 @@ func (t *CodeEditor) HideSuggestionList() {
 }
 
 func (t *CodeEditor) Line(idx int) TextBoxLine {
-	id := gxui.AdapterItemId(idx)
-	return gxui.FindControl(t.Item(id), func(c gxui.Control) bool {
+	return gxui.FindControl(t.ItemControl(idx), func(c gxui.Control) bool {
 		_, b := c.(TextBoxLine)
 		return b
 	}).(TextBoxLine)

--- a/mixins/code_suggestion_adapter.go
+++ b/mixins/code_suggestion_adapter.go
@@ -21,6 +21,6 @@ func (a *SuggestionAdapter) SetSuggestions(suggestions []gxui.CodeSuggestion) {
 	a.SetItems(items)
 }
 
-func (a *SuggestionAdapter) Suggestion(id gxui.AdapterItemId) gxui.CodeSuggestion {
-	return a.Item(id).Data.(gxui.CodeSuggestion)
+func (a *SuggestionAdapter) Suggestion(item gxui.AdapterItem) gxui.CodeSuggestion {
+	return item.(gxui.FilteredListItem).Data.(gxui.CodeSuggestion)
 }

--- a/mixins/drop_down_list.go
+++ b/mixins/drop_down_list.go
@@ -93,7 +93,7 @@ func (l *DropDownList) DesiredSize(min, max math.Size) math.Size {
 
 func (l *DropDownList) DataReplaced() {
 	adapter := l.list.Adapter()
-	itemSize := adapter.ItemSize(l.theme)
+	itemSize := adapter.Size(l.theme)
 	l.itemSize = itemSize
 	l.outer.Relayout()
 }

--- a/mixins/drop_down_list.go
+++ b/mixins/drop_down_list.go
@@ -22,14 +22,14 @@ type DropDownList struct {
 
 	outer DropDownListOuter
 
-	theme        gxui.Theme
-	list         gxui.List
-	listShowing  bool
-	itemSize     math.Size
-	overlay      gxui.BubbleOverlay
-	selectedItem gxui.Control
-	onShowList   gxui.Event
-	onHideList   gxui.Event
+	theme       gxui.Theme
+	list        gxui.List
+	listShowing bool
+	itemSize    math.Size
+	overlay     gxui.BubbleOverlay
+	selected    gxui.Control
+	onShowList  gxui.Event
+	onHideList  gxui.Event
 }
 
 func (l *DropDownList) Init(outer DropDownListOuter, theme gxui.Theme) {
@@ -40,16 +40,16 @@ func (l *DropDownList) Init(outer DropDownListOuter, theme gxui.Theme) {
 
 	l.theme = theme
 	l.list = theme.CreateList()
-	l.list.OnSelectionChanged(func(id gxui.AdapterItemId) {
+	l.list.OnSelectionChanged(func(item gxui.AdapterItem) {
 		adapter := l.list.Adapter()
-		if id != gxui.InvalidAdapterItemId && adapter != nil {
-			l.selectedItem = adapter.Create(l.theme, adapter.ItemIndex(id))
+		if item != nil && adapter != nil {
+			l.selected = adapter.Create(l.theme, adapter.ItemIndex(item))
 		} else {
-			l.selectedItem = nil
+			l.selected = nil
 		}
 		l.Relayout()
 	})
-	l.list.OnItemClicked(func(gxui.MouseEvent, gxui.AdapterItemId) {
+	l.list.OnItemClicked(func(gxui.MouseEvent, gxui.AdapterItem) {
 		l.HideList()
 	})
 	l.list.OnKeyPress(func(ev gxui.KeyboardEvent) {
@@ -75,17 +75,17 @@ func (l *DropDownList) LayoutChildren() {
 
 	l.outer.RemoveAll()
 
-	if l.selectedItem != nil {
+	if l.selected != nil {
 		s := l.outer.Bounds().Size().Contract(l.Padding()).Max(math.ZeroSize)
 		o := l.Padding().LT()
-		l.selectedItem.Layout(s.Rect().Offset(o))
-		l.AddChild(l.selectedItem)
+		l.selected.Layout(s.Rect().Offset(o))
+		l.AddChild(l.selected)
 	}
 }
 
 func (l *DropDownList) DesiredSize(min, max math.Size) math.Size {
-	if l.selectedItem != nil {
-		return l.selectedItem.DesiredSize(min, max).Expand(l.outer.Padding()).Clamp(min, max)
+	if l.selected != nil {
+		return l.selected.DesiredSize(min, max).Expand(l.outer.Padding()).Clamp(min, max)
 	} else {
 		return l.itemSize.Expand(l.outer.Padding()).Clamp(min, max)
 	}
@@ -170,18 +170,18 @@ func (l *DropDownList) SetAdapter(adapter gxui.Adapter) {
 	}
 }
 
-func (l *DropDownList) Selected() gxui.AdapterItemId {
+func (l *DropDownList) Selected() gxui.AdapterItem {
 	return l.list.Selected()
 }
 
-func (l *DropDownList) Select(id gxui.AdapterItemId) {
-	if l.list.Selected() != id {
-		l.list.Select(id)
+func (l *DropDownList) Select(item gxui.AdapterItem) {
+	if l.list.Selected() != item {
+		l.list.Select(item)
 		l.LayoutChildren()
 	}
 }
 
-func (l *DropDownList) OnSelectionChanged(f func(gxui.AdapterItemId)) gxui.EventSubscription {
+func (l *DropDownList) OnSelectionChanged(f func(gxui.AdapterItem)) gxui.EventSubscription {
 	return l.list.OnSelectionChanged(f)
 }
 

--- a/mixins/list.go
+++ b/mixins/list.go
@@ -21,11 +21,11 @@ type ListOuter interface {
 	PaintBorder(c gxui.Canvas, r math.Rect)
 }
 
-type ListItem struct {
-	Control             gxui.Control
-	Index               int
-	Mark                int
-	OnClickSubscription gxui.EventSubscription
+type itemDetails struct {
+	control             gxui.Control
+	index               int
+	mark                int
+	onClickSubscription gxui.EventSubscription
 }
 
 type List struct {
@@ -39,9 +39,9 @@ type List struct {
 	adapter                  gxui.Adapter
 	scrollBar                gxui.ScrollBar
 	scrollBarEnabled         bool
-	selectedId               gxui.AdapterItemId
+	selectedItem             gxui.AdapterItem
 	onSelectionChanged       gxui.Event
-	items                    map[gxui.AdapterItemId]ListItem
+	details                  map[gxui.AdapterItem]itemDetails
 	orientation              gxui.Orientation
 	scrollOffset             int
 	itemSize                 math.Size
@@ -64,12 +64,11 @@ func (l *List) Init(outer ListOuter, theme gxui.Theme) {
 	l.scrollBar = theme.CreateScrollBar()
 	l.scrollBarEnabled = true
 	l.scrollBar.OnScroll(func(from, to int) { l.SetScrollOffset(from) })
-	l.selectedId = gxui.InvalidAdapterItemId
 	l.SetOrientation(gxui.Vertical)
 	l.SetBackgroundBrush(gxui.TransparentBrush)
 	l.SetMouseEventTarget(true)
 
-	l.items = make(map[gxui.AdapterItemId]ListItem)
+	l.details = make(map[gxui.AdapterItem]itemDetails)
 
 	// Interface compliance test
 	_ = gxui.List(l)
@@ -83,10 +82,10 @@ func (l *List) UpdateItemMouseOver() {
 		}
 		return
 	}
-	for _, item := range l.items {
-		if item.Control.Bounds().Contains(l.mousePosition) {
-			if l.itemMouseOver != item.Control {
-				l.itemMouseOver = item.Control
+	for _, details := range l.details {
+		if details.control.Bounds().Contains(l.mousePosition) {
+			if l.itemMouseOver != details.control {
+				l.itemMouseOver = details.control
 				l.Redraw()
 				return
 			}
@@ -125,26 +124,26 @@ func (l *List) LayoutChildren() {
 	l.layoutMark++
 
 	for idx := startIndex; idx < endIndex; idx++ {
-		id := l.adapter.ItemId(idx)
+		item := l.adapter.ItemAt(idx)
 
-		item, found := l.items[id]
+		details, found := l.details[item]
 		if found {
-			if item.Mark == mark {
-				panic(fmt.Errorf("Adapter returned duplicate id (%v) for indices %v and %v",
-					id, item.Index, idx))
+			if details.mark == mark {
+				panic(fmt.Errorf("Adapter returned duplicate item (%v) for indices %v and %v",
+					item, details.index, idx))
 			}
 		} else {
-			item.Control = l.adapter.Create(l.theme, idx)
-			item.OnClickSubscription = item.Control.OnClick(func(ev gxui.MouseEvent) {
-				l.ItemClicked(ev, id)
+			details.control = l.adapter.Create(l.theme, idx)
+			details.onClickSubscription = details.control.OnClick(func(ev gxui.MouseEvent) {
+				l.ItemClicked(ev, item)
 			})
-			l.AddChildAt(0, item.Control)
+			l.AddChildAt(0, details.control)
 		}
-		item.Mark = mark
-		item.Index = idx
-		l.items[id] = item
+		details.mark = mark
+		details.index = idx
+		l.details[item] = details
 
-		c := item.Control
+		c := details.control
 		cm := c.Margin()
 		cs := itemSize.Contract(cm).Max(math.ZeroSize)
 		if l.orientation.Horizontal() {
@@ -156,11 +155,11 @@ func (l *List) LayoutChildren() {
 	}
 
 	// Reap unused items
-	for id, item := range l.items {
-		if item.Mark != mark {
-			item.OnClickSubscription.Unlisten()
-			l.RemoveChild(item.Control)
-			delete(l.items, id)
+	for item, details := range l.details {
+		if details.mark != mark {
+			details.onClickSubscription.Unlisten()
+			l.RemoveChild(details.control)
+			delete(l.details, item)
 		}
 	}
 
@@ -286,11 +285,11 @@ func (l *List) DataChanged() {
 }
 
 func (l *List) DataReplaced() {
-	l.selectedId = gxui.InvalidAdapterItemId
-	for id, item := range l.items {
-		item.OnClickSubscription.Unlisten()
-		l.RemoveChild(item.Control)
-		delete(l.items, id)
+	l.selectedItem = nil
+	for item, details := range l.details {
+		details.onClickSubscription.Unlisten()
+		l.RemoveChild(details.control)
+		delete(l.details, item)
 	}
 	l.DataChanged()
 }
@@ -311,20 +310,20 @@ func (l *List) PaintMouseOverBackground(c gxui.Canvas, r math.Rect) {
 }
 
 func (l *List) SelectPrevious() {
-	if l.selectedId != gxui.InvalidAdapterItemId {
-		selectedIndex := l.adapter.ItemIndex(l.selectedId)
-		l.Select(l.adapter.ItemId(math.Mod(selectedIndex-1, l.itemCount)))
+	if l.selectedItem != nil {
+		selectedIndex := l.adapter.ItemIndex(l.selectedItem)
+		l.Select(l.adapter.ItemAt(math.Mod(selectedIndex-1, l.itemCount)))
 	} else {
-		l.Select(l.adapter.ItemId(0))
+		l.Select(l.adapter.ItemAt(0))
 	}
 }
 
 func (l *List) SelectNext() {
-	if l.selectedId != gxui.InvalidAdapterItemId {
-		selectedIndex := l.adapter.ItemIndex(l.selectedId)
-		l.Select(l.adapter.ItemId(math.Mod(selectedIndex+1, l.itemCount)))
+	if l.selectedItem != nil {
+		selectedIndex := l.adapter.ItemIndex(l.selectedItem)
+		l.Select(l.adapter.ItemAt(math.Mod(selectedIndex+1, l.itemCount)))
 	} else {
-		l.Select(l.adapter.ItemId(0))
+		l.Select(l.adapter.ItemAt(0))
 	}
 }
 
@@ -335,8 +334,8 @@ func (l *List) PaintChild(c gxui.Canvas, child gxui.Control, idx int) {
 		l.outer.PaintMouseOverBackground(c, b)
 	}
 	l.PaintChildren.PaintChild(c, child, idx)
-	if selected, found := l.items[l.selectedId]; found {
-		if child == selected.Control {
+	if selected, found := l.details[l.selectedItem]; found {
+		if child == selected.control {
 			b := child.Bounds().Expand(child.Margin())
 			l.outer.PaintSelection(c, b)
 		}
@@ -439,8 +438,8 @@ func (l *List) SetOrientation(o gxui.Orientation) {
 	}
 }
 
-func (l *List) ScrollTo(id gxui.AdapterItemId) {
-	idx := l.adapter.ItemIndex(id)
+func (l *List) ScrollTo(item gxui.AdapterItem) {
+	idx := l.adapter.ItemIndex(item)
 	startIndex, endIndex := l.VisibleItemRange(false)
 	if idx < startIndex {
 		if l.Orientation().Horizontal() {
@@ -458,48 +457,48 @@ func (l *List) ScrollTo(id gxui.AdapterItemId) {
 	}
 }
 
-func (l *List) IsItemVisible(id gxui.AdapterItemId) bool {
-	_, found := l.items[id]
+func (l *List) IsItemVisible(item gxui.AdapterItem) bool {
+	_, found := l.details[item]
 	return found
 }
 
-func (l *List) Item(id gxui.AdapterItemId) gxui.Control {
-	if item, found := l.items[id]; found {
-		return item.Control
+func (l *List) ItemControl(item gxui.AdapterItem) gxui.Control {
+	if item, found := l.details[item]; found {
+		return item.control
 	}
 	return nil
 }
 
-func (l *List) ItemClicked(ev gxui.MouseEvent, id gxui.AdapterItemId) {
+func (l *List) ItemClicked(ev gxui.MouseEvent, item gxui.AdapterItem) {
 	if l.onItemClicked != nil {
-		l.onItemClicked.Fire(ev, id)
+		l.onItemClicked.Fire(ev, item)
 	}
-	l.Select(id)
+	l.Select(item)
 }
 
-func (l *List) OnItemClicked(f func(gxui.MouseEvent, gxui.AdapterItemId)) gxui.EventSubscription {
+func (l *List) OnItemClicked(f func(gxui.MouseEvent, gxui.AdapterItem)) gxui.EventSubscription {
 	if l.onItemClicked == nil {
 		l.onItemClicked = gxui.CreateEvent(f)
 	}
 	return l.onItemClicked.Listen(f)
 }
 
-func (l *List) Selected() gxui.AdapterItemId {
-	return l.selectedId
+func (l *List) Selected() gxui.AdapterItem {
+	return l.selectedItem
 }
 
-func (l *List) Select(id gxui.AdapterItemId) {
-	if l.selectedId != id {
-		l.selectedId = id
+func (l *List) Select(item gxui.AdapterItem) {
+	if l.selectedItem != item {
+		l.selectedItem = item
 		if l.onSelectionChanged != nil {
-			l.onSelectionChanged.Fire(id)
+			l.onSelectionChanged.Fire(item)
 		}
 		l.Redraw()
 	}
-	l.ScrollTo(id)
+	l.ScrollTo(item)
 }
 
-func (l *List) OnSelectionChanged(f func(gxui.AdapterItemId)) gxui.EventSubscription {
+func (l *List) OnSelectionChanged(f func(gxui.AdapterItem)) gxui.EventSubscription {
 	if l.onItemClicked == nil {
 		l.onSelectionChanged = gxui.CreateEvent(f)
 	}

--- a/mixins/list.go
+++ b/mixins/list.go
@@ -272,8 +272,8 @@ func (l *List) VisibleItemRange(includePartiallyVisible bool) (startIndex, endIn
 	return startIndex, endIndex
 }
 
-func (l *List) ItemSizeChanged() {
-	l.itemSize = l.adapter.ItemSize(l.theme)
+func (l *List) SizeChanged() {
+	l.itemSize = l.adapter.Size(l.theme)
 	l.scrollBar.SetScrollLimit(l.itemCount * l.MajorAxisItemSize())
 	l.SetScrollOffset(l.scrollOffset)
 	l.outer.Relayout()
@@ -281,7 +281,7 @@ func (l *List) ItemSizeChanged() {
 
 func (l *List) DataChanged() {
 	l.itemCount = l.adapter.Count()
-	l.ItemSizeChanged()
+	l.SizeChanged()
 }
 
 func (l *List) DataReplaced() {

--- a/mixins/textbox.go
+++ b/mixins/textbox.go
@@ -19,7 +19,6 @@ type TextBoxLine interface {
 
 type TextBoxOuter interface {
 	ListOuter
-	gxui.Adapter
 	CreateLine(theme gxui.Theme, index int) (line TextBoxLine, container gxui.Control)
 }
 
@@ -35,6 +34,7 @@ type TextBox struct {
 	onRedrawLines     gxui.Event
 	multiline         bool
 	controller        *gxui.TextBoxController
+	adapter           *TextBoxAdapter
 	selectionDragging bool
 	selectionDrag     gxui.TextSelection
 	desiredWidth      int
@@ -70,6 +70,7 @@ func (t *TextBox) Init(outer TextBoxOuter, driver gxui.Driver, theme gxui.Theme,
 	t.font = font
 	t.onRedrawLines = gxui.CreateEvent(func() {})
 	t.controller = gxui.CreateTextBoxController()
+	t.adapter = &TextBoxAdapter{TextBox: t}
 	t.desiredWidth = 100
 	t.SetScrollBarEnabled(false) // Defaults to single line
 	t.OnGainedFocus(func() { t.onRedrawLines.Fire() })
@@ -82,11 +83,10 @@ func (t *TextBox) Init(outer TextBoxOuter, driver gxui.Driver, theme gxui.Theme,
 		t.onRedrawLines.Fire()
 	})
 
-	t.List.SetAdapter(t.outer)
+	t.List.SetAdapter(t.adapter)
 
 	// Interface compliance test
 	_ = gxui.TextBox(t)
-	_ = gxui.Adapter(t)
 }
 
 func (t *TextBox) textRect() math.Rect {
@@ -161,7 +161,7 @@ func (t *TextBox) DesiredWidth() int {
 func (t *TextBox) SetDesiredWidth(desiredWidth int) {
 	if t.desiredWidth != desiredWidth {
 		t.desiredWidth = desiredWidth
-		t.ItemSizeChanged()
+		t.SizeChanged()
 	}
 }
 
@@ -441,25 +441,35 @@ func (t *TextBox) PaintSelection(c gxui.Canvas, r math.Rect) {}
 func (t *TextBox) PaintMouseOverBackground(c gxui.Canvas, r math.Rect) {}
 
 // gxui.AdapterCompliance
-func (t *TextBox) ItemSize(theme gxui.Theme) math.Size {
-	return math.Size{W: t.desiredWidth, H: t.font.GlyphMaxSize().H}
+type TextBoxAdapter struct {
+	gxui.DefaultAdapter
+	TextBox *TextBox
 }
 
-func (t *TextBox) Count() int {
-	return math.Max(t.controller.LineCount(), 1)
+func (t *TextBoxAdapter) Count() int {
+	return math.Max(t.TextBox.controller.LineCount(), 1)
 }
 
-func (t *TextBox) ItemAt(index int) gxui.AdapterItem {
+func (t *TextBoxAdapter) ItemAt(index int) gxui.AdapterItem {
 	return index
 }
 
-func (t *TextBox) ItemIndex(item gxui.AdapterItem) int {
+func (t *TextBoxAdapter) ItemIndex(item gxui.AdapterItem) int {
 	return item.(int)
 }
 
-func (t *TextBox) Create(theme gxui.Theme, index int) gxui.Control {
-	line, container := t.outer.CreateLine(theme, index)
-	line.OnMouseDown(func(ev gxui.MouseEvent) { t.lineMouseDown(line, ev) })
-	line.OnMouseUp(func(ev gxui.MouseEvent) { t.lineMouseUp(line, ev) })
+func (t *TextBoxAdapter) Size(theme gxui.Theme) math.Size {
+	tb := t.TextBox
+	return math.Size{W: tb.desiredWidth, H: tb.font.GlyphMaxSize().H}
+}
+
+func (t *TextBoxAdapter) Create(theme gxui.Theme, index int) gxui.Control {
+	line, container := t.TextBox.outer.CreateLine(theme, index)
+	line.OnMouseDown(func(ev gxui.MouseEvent) {
+		t.TextBox.lineMouseDown(line, ev)
+	})
+	line.OnMouseUp(func(ev gxui.MouseEvent) {
+		t.TextBox.lineMouseUp(line, ev)
+	})
 	return container
 }

--- a/mixins/textbox.go
+++ b/mixins/textbox.go
@@ -218,7 +218,7 @@ func (t *TextBox) LineEnd(line int) int {
 }
 
 func (t *TextBox) ScrollToLine(i int) {
-	t.List.ScrollTo(gxui.AdapterItemId(i))
+	t.List.ScrollTo(i)
 }
 
 func (t *TextBox) ScrollToRune(i int) {
@@ -449,12 +449,12 @@ func (t *TextBox) Count() int {
 	return math.Max(t.controller.LineCount(), 1)
 }
 
-func (t *TextBox) ItemId(index int) gxui.AdapterItemId {
-	return gxui.AdapterItemId(index)
+func (t *TextBox) ItemAt(index int) gxui.AdapterItem {
+	return index
 }
 
-func (t *TextBox) ItemIndex(id gxui.AdapterItemId) int {
-	return int(id)
+func (t *TextBox) ItemIndex(item gxui.AdapterItem) int {
+	return item.(int)
 }
 
 func (t *TextBox) Create(theme gxui.Theme, index int) gxui.Control {

--- a/mixins/tree.go
+++ b/mixins/tree.go
@@ -53,9 +53,9 @@ func (t *Tree) Adapter() gxui.TreeAdapter {
 	return t.adapterInner
 }
 
-func (t *Tree) Show(id gxui.AdapterItemId) {
-	t.adapterOuter.ExpandAllParents(id)
-	t.List.ScrollTo(id)
+func (t *Tree) Show(item gxui.AdapterItem) {
+	t.adapterOuter.ExpandAllParents(item)
+	t.List.ScrollTo(item)
 }
 
 func (t *Tree) ExpandAll() {
@@ -102,13 +102,13 @@ func (t *Tree) PaintUnexpandedSelection(c gxui.Canvas, r math.Rect) {
 // List override
 func (t *Tree) PaintChild(c gxui.Canvas, child gxui.Control, idx int) {
 	t.List.PaintChild(c, child, idx)
-	if t.selectedId != gxui.InvalidAdapterItemId {
-		id := t.adapterOuter.DeepestVisibleAncestor(t.selectedId)
-		if id != t.selectedId {
+	if t.selectedItem != nil {
+		item := t.adapterOuter.DeepestVisibleAncestor(t.selectedItem)
+		if item != t.selectedItem {
 			// The selected item is hidden by an unexpanded node.
 			// Highlight the deepest visible node instead.
-			if item, found := t.items[id]; found {
-				if child == item.Control {
+			if details, found := t.details[item]; found {
+				if child == details.control {
 					b := child.Bounds().Expand(child.Margin())
 					t.outer.PaintUnexpandedSelection(c, b)
 				}
@@ -119,16 +119,16 @@ func (t *Tree) PaintChild(c gxui.Canvas, child gxui.Control, idx int) {
 
 // InputEventHandler override
 func (t *Tree) KeyPress(ev gxui.KeyboardEvent) (consume bool) {
-	id := t.Selected()
+	item := t.Selected()
 	switch ev.Key {
 	case gxui.KeyLeft:
-		newId := t.adapterOuter.Collapse(id)
-		if newId != id {
-			t.Select(newId)
+		newItem := t.adapterOuter.Collapse(item)
+		if newItem != item {
+			t.Select(newItem)
 			return true
 		}
 	case gxui.KeyRight:
-		if t.adapterOuter.Expand(id) {
+		if t.adapterOuter.Expand(item) {
 			return true
 		}
 	}

--- a/mixins/tree_internal_node_test.go
+++ b/mixins/tree_internal_node_test.go
@@ -13,7 +13,7 @@ import (
 
 type testTreeAdapterNode struct {
 	gxui.AdapterBase
-	id       gxui.AdapterItemId
+	item     gxui.AdapterItem
 	children []*testTreeAdapterNode
 }
 
@@ -21,16 +21,16 @@ func (n *testTreeAdapterNode) Count() int {
 	return len(n.children)
 }
 
-func (n *testTreeAdapterNode) ItemId(index int) gxui.AdapterItemId {
-	return n.children[index].id
+func (n *testTreeAdapterNode) ItemAt(index int) gxui.AdapterItem {
+	return n.children[index].item
 }
 
-func (n *testTreeAdapterNode) ItemIndex(id gxui.AdapterItemId) int {
+func (n *testTreeAdapterNode) ItemIndex(item gxui.AdapterItem) int {
 	for i, c := range n.children {
-		if id == c.id {
+		if item == c.item {
 			return i
 		}
-		if idx := c.ItemIndex(id); idx >= 0 {
+		if idx := c.ItemIndex(item); idx >= 0 {
 			return i
 		}
 	}
@@ -49,8 +49,8 @@ func (n *testTreeAdapterNode) ItemSize(gxui.Theme) math.Size {
 	return math.ZeroSize
 }
 
-func createTestTreeNode(id gxui.AdapterItemId, subnodes ...*testTreeAdapterNode) *testTreeAdapterNode {
-	return &testTreeAdapterNode{id: id, children: subnodes}
+func createTestTreeNode(item gxui.AdapterItem, subnodes ...*testTreeAdapterNode) *testTreeAdapterNode {
+	return &testTreeAdapterNode{item: item, children: subnodes}
 }
 
 func TestTINFlatSimple(t *testing.T) {
@@ -58,9 +58,9 @@ func TestTINFlatSimple(t *testing.T) {
 	root := CreateTreeInternalRoot(N(0, N(10), N(20), N(30)))
 
 	test.AssertEquals(t, 3, root.childCount)
-	test.AssertEquals(t, gxui.AdapterItemId(10), root.ItemId(0))
-	test.AssertEquals(t, gxui.AdapterItemId(20), root.ItemId(1))
-	test.AssertEquals(t, gxui.AdapterItemId(30), root.ItemId(2))
+	test.AssertEquals(t, gxui.AdapterItem(10), root.ItemAt(0))
+	test.AssertEquals(t, gxui.AdapterItem(20), root.ItemAt(1))
+	test.AssertEquals(t, gxui.AdapterItem(30), root.ItemAt(2))
 }
 
 func TestTINDeepNoExpand(t *testing.T) {
@@ -75,9 +75,9 @@ func TestTINDeepNoExpand(t *testing.T) {
 	))
 
 	test.AssertEquals(t, 3, root.childCount)
-	test.AssertEquals(t, gxui.AdapterItemId(10), root.ItemId(0))
-	test.AssertEquals(t, gxui.AdapterItemId(20), root.ItemId(1))
-	test.AssertEquals(t, gxui.AdapterItemId(30), root.ItemId(2))
+	test.AssertEquals(t, gxui.AdapterItem(10), root.ItemAt(0))
+	test.AssertEquals(t, gxui.AdapterItem(20), root.ItemAt(1))
+	test.AssertEquals(t, gxui.AdapterItem(30), root.ItemAt(2))
 }
 
 func TestTINFindByIndex(t *testing.T) {
@@ -113,7 +113,7 @@ func TestTINFindByIndex(t *testing.T) {
 	test.AssertEquals(t, 2, d)
 }
 
-func TestTINFindById(t *testing.T) {
+func TestTINFindByItem(t *testing.T) {
 	N := createTestTreeNode
 	root := CreateTreeInternalRoot(N(0,
 		/*0*/ N(100,
@@ -130,17 +130,17 @@ func TestTINFindById(t *testing.T) {
 	root.ExpandAll()
 	test.AssertEquals(t, 10, root.childCount)
 
-	n, i, d := root.FindById(100)
+	n, i, d := root.FindByItem(100)
 	test.AssertEquals(t, root, n)
 	test.AssertEquals(t, 0, i)
 	test.AssertEquals(t, 0, d)
 
-	n, i, d = root.FindById(122)
+	n, i, d = root.FindByItem(122)
 	test.AssertEquals(t, root.Child(0).Child(1), n)
 	test.AssertEquals(t, 1, i)
 	test.AssertEquals(t, 2, d)
 
-	n, i, d = root.FindById(141)
+	n, i, d = root.FindByItem(141)
 	test.AssertEquals(t, root.Child(0).Child(3), n)
 	test.AssertEquals(t, 0, i)
 	test.AssertEquals(t, 2, d)
@@ -159,18 +159,18 @@ func TestTINExpandExpandFirst(t *testing.T) {
 
 	root.Child(0).Expand()
 	test.AssertEquals(t, 7, root.childCount)
-	test.AssertEquals(t, gxui.AdapterItemId(10), root.ItemId(0))
-	test.AssertEquals(t, gxui.AdapterItemId(11), root.ItemId(1))
-	test.AssertEquals(t, gxui.AdapterItemId(12), root.ItemId(2))
-	test.AssertEquals(t, gxui.AdapterItemId(13), root.ItemId(3))
-	test.AssertEquals(t, gxui.AdapterItemId(14), root.ItemId(4))
-	test.AssertEquals(t, gxui.AdapterItemId(20), root.ItemId(5))
+	test.AssertEquals(t, gxui.AdapterItem(10), root.ItemAt(0))
+	test.AssertEquals(t, gxui.AdapterItem(11), root.ItemAt(1))
+	test.AssertEquals(t, gxui.AdapterItem(12), root.ItemAt(2))
+	test.AssertEquals(t, gxui.AdapterItem(13), root.ItemAt(3))
+	test.AssertEquals(t, gxui.AdapterItem(14), root.ItemAt(4))
+	test.AssertEquals(t, gxui.AdapterItem(20), root.ItemAt(5))
 
 	root.Child(0).Collapse()
 	test.AssertEquals(t, 3, root.childCount)
-	test.AssertEquals(t, gxui.AdapterItemId(10), root.ItemId(0))
-	test.AssertEquals(t, gxui.AdapterItemId(20), root.ItemId(1))
-	test.AssertEquals(t, gxui.AdapterItemId(30), root.ItemId(2))
+	test.AssertEquals(t, gxui.AdapterItem(10), root.ItemAt(0))
+	test.AssertEquals(t, gxui.AdapterItem(20), root.ItemAt(1))
+	test.AssertEquals(t, gxui.AdapterItem(30), root.ItemAt(2))
 }
 
 func TestTINExpandCollapseOne(t *testing.T) {
@@ -186,17 +186,17 @@ func TestTINExpandCollapseOne(t *testing.T) {
 
 	root.Child(1).Expand()
 	test.AssertEquals(t, root.childCount, 7)
-	test.AssertEquals(t, gxui.AdapterItemId(10), root.ItemId(0))
-	test.AssertEquals(t, gxui.AdapterItemId(20), root.ItemId(1))
-	test.AssertEquals(t, gxui.AdapterItemId(21), root.ItemId(2))
-	test.AssertEquals(t, gxui.AdapterItemId(24), root.ItemId(5))
-	test.AssertEquals(t, gxui.AdapterItemId(30), root.ItemId(6))
+	test.AssertEquals(t, gxui.AdapterItem(10), root.ItemAt(0))
+	test.AssertEquals(t, gxui.AdapterItem(20), root.ItemAt(1))
+	test.AssertEquals(t, gxui.AdapterItem(21), root.ItemAt(2))
+	test.AssertEquals(t, gxui.AdapterItem(24), root.ItemAt(5))
+	test.AssertEquals(t, gxui.AdapterItem(30), root.ItemAt(6))
 
 	root.Child(1).Collapse()
 	test.AssertEquals(t, root.childCount, 3)
-	test.AssertEquals(t, gxui.AdapterItemId(10), root.ItemId(0))
-	test.AssertEquals(t, gxui.AdapterItemId(20), root.ItemId(1))
-	test.AssertEquals(t, gxui.AdapterItemId(30), root.ItemId(2))
+	test.AssertEquals(t, gxui.AdapterItem(10), root.ItemAt(0))
+	test.AssertEquals(t, gxui.AdapterItem(20), root.ItemAt(1))
+	test.AssertEquals(t, gxui.AdapterItem(30), root.ItemAt(2))
 }
 
 func TestTINGExpandAll(t *testing.T) {

--- a/mixins/tree_to_list_adapter.go
+++ b/mixins/tree_to_list_adapter.go
@@ -33,33 +33,33 @@ func CreateTreeToListAdapter(inner gxui.TreeAdapter, ceb CreateExpandButton) *Tr
 	return outer
 }
 
-func (a TreeToListAdapter) Collapse(id gxui.AdapterItemId) gxui.AdapterItemId {
-	n, i, _ := a.root.FindById(id)
+func (a TreeToListAdapter) Collapse(item gxui.AdapterItem) gxui.AdapterItem {
+	n, i, _ := a.root.FindByItem(item)
 	if n.Child(i).Collapse() {
-		return n.Child(i).Id()
+		return n.Child(i).Item()
 	}
 	if n != a.root && n.Collapse() {
-		return n.Id()
+		return n.Item()
 	}
-	return id
+	return item
 }
 
-func (a TreeToListAdapter) Expand(id gxui.AdapterItemId) bool {
-	n, i, _ := a.root.FindById(id)
+func (a TreeToListAdapter) Expand(item gxui.AdapterItem) bool {
+	n, i, _ := a.root.FindByItem(item)
 	return n.Child(i).Expand()
 }
 
-func (a TreeToListAdapter) ExpandAllParents(id gxui.AdapterItemId) bool {
-	for a.Expand(a.DeepestVisibleAncestor(id)) {
+func (a TreeToListAdapter) ExpandAllParents(item gxui.AdapterItem) bool {
+	for a.Expand(a.DeepestVisibleAncestor(item)) {
 	}
 	a.DataChanged()
 	return false
 }
 
-func (a TreeToListAdapter) DeepestVisibleAncestor(id gxui.AdapterItemId) gxui.AdapterItemId {
-	n, i, _ := a.root.FindById(id)
+func (a TreeToListAdapter) DeepestVisibleAncestor(item gxui.AdapterItem) gxui.AdapterItem {
+	n, i, _ := a.root.FindByItem(item)
 	child := n.Child(i)
-	return child.Id()
+	return child.Item()
 }
 
 // Adapter compliance
@@ -71,12 +71,12 @@ func (a TreeToListAdapter) Count() int {
 	return a.root.childCount
 }
 
-func (a TreeToListAdapter) ItemId(index int) gxui.AdapterItemId {
-	return a.root.ItemId(index)
+func (a TreeToListAdapter) ItemAt(index int) gxui.AdapterItem {
+	return a.root.ItemAt(index)
 }
 
-func (a TreeToListAdapter) ItemIndex(id gxui.AdapterItemId) int {
-	return a.root.ItemIndex(id)
+func (a TreeToListAdapter) ItemIndex(item gxui.AdapterItem) int {
+	return a.root.ItemIndex(item)
 }
 
 func (a TreeToListAdapter) Create(theme gxui.Theme, index int) gxui.Control {

--- a/mixins/tree_to_list_adapter.go
+++ b/mixins/tree_to_list_adapter.go
@@ -63,10 +63,6 @@ func (a TreeToListAdapter) DeepestVisibleAncestor(item gxui.AdapterItem) gxui.Ad
 }
 
 // Adapter compliance
-func (a TreeToListAdapter) ItemSize(theme gxui.Theme) math.Size {
-	return a.adapter.ItemSize(theme)
-}
-
 func (a TreeToListAdapter) Count() int {
 	return a.root.childCount
 }
@@ -77,6 +73,10 @@ func (a TreeToListAdapter) ItemAt(index int) gxui.AdapterItem {
 
 func (a TreeToListAdapter) ItemIndex(item gxui.AdapterItem) int {
 	return a.root.ItemIndex(item)
+}
+
+func (a TreeToListAdapter) Size(theme gxui.Theme) math.Size {
+	return a.adapter.Size(theme)
 }
 
 func (a TreeToListAdapter) Create(theme gxui.Theme, index int) gxui.Control {

--- a/samples/lists/main.go
+++ b/samples/lists/main.go
@@ -61,7 +61,7 @@ func (a *customAdapter) Count() int {
 }
 
 func (a *customAdapter) ItemAt(index int) gxui.AdapterItem {
-	return index // This adapter stores integer indices the items
+	return index // This adapter uses integer indices as AdapterItems
 }
 
 func (a *customAdapter) ItemIndex(item gxui.AdapterItem) int {

--- a/samples/lists/main.go
+++ b/samples/lists/main.go
@@ -56,18 +56,22 @@ type customAdapter struct {
 	gxui.AdapterBase
 }
 
-func (a *customAdapter) ItemSize(theme gxui.Theme) math.Size {
-	return math.Size{W: 100, H: 100}
-}
 func (a *customAdapter) Count() int {
 	return 1000
 }
+
 func (a *customAdapter) ItemAt(index int) gxui.AdapterItem {
 	return index // This adapter stores integer indices the items
 }
+
 func (a *customAdapter) ItemIndex(item gxui.AdapterItem) int {
 	return item.(int) // Inverse of ItemAt()
 }
+
+func (a *customAdapter) Size(theme gxui.Theme) math.Size {
+	return math.Size{W: 100, H: 100}
+}
+
 func (a *customAdapter) Create(theme gxui.Theme, index int) gxui.Control {
 	phase := float32(index) / 1000
 	c := gxui.Color{

--- a/samples/lists/main.go
+++ b/samples/lists/main.go
@@ -15,7 +15,7 @@ import (
 
 // Number picker uses the gxui.DefaultAdapter for driving a list
 func numberPicker(theme gxui.Theme) gxui.Control {
-	data := []string{
+	items := []string{
 		"zero", "one", "two", "three", "four", "five",
 		"six", "seven", "eight", "nine", "ten",
 		"eleven", "twelve", "thirteen", "fourteen", "fifteen",
@@ -23,7 +23,7 @@ func numberPicker(theme gxui.Theme) gxui.Control {
 	}
 
 	adapter := gxui.CreateDefaultAdapter()
-	adapter.SetData(data)
+	adapter.SetItems(items)
 
 	layout := theme.CreateLinearLayout()
 	layout.SetOrientation(gxui.Vertical)
@@ -45,10 +45,8 @@ func numberPicker(theme gxui.Theme) gxui.Control {
 	selected := theme.CreateLabel()
 	layout.AddChild(selected)
 
-	list.OnSelectionChanged(func(id gxui.AdapterItemId) {
-		if id != gxui.InvalidAdapterItemId {
-			selected.SetText(fmt.Sprintf("%s - %d", adapter.ValueOf(id), id))
-		}
+	list.OnSelectionChanged(func(item gxui.AdapterItem) {
+		selected.SetText(fmt.Sprintf("%s - %d", item, adapter.ItemIndex(item)))
 	})
 
 	return layout
@@ -64,11 +62,11 @@ func (a *customAdapter) ItemSize(theme gxui.Theme) math.Size {
 func (a *customAdapter) Count() int {
 	return 1000
 }
-func (a *customAdapter) ItemId(index int) gxui.AdapterItemId {
-	return gxui.AdapterItemId(index)
+func (a *customAdapter) ItemAt(index int) gxui.AdapterItem {
+	return index // This adapter stores integer indices the items
 }
-func (a *customAdapter) ItemIndex(id gxui.AdapterItemId) int {
-	return int(id)
+func (a *customAdapter) ItemIndex(item gxui.AdapterItem) int {
+	return item.(int) // Inverse of ItemAt()
 }
 func (a *customAdapter) Create(theme gxui.Theme, index int) gxui.Control {
 	phase := float32(index) / 1000
@@ -121,9 +119,10 @@ func colorPicker(theme gxui.Theme) gxui.Control {
 	selected.SetExplicitSize(math.Size{W: 32, H: 32})
 	layout.AddChild(selected)
 
-	list.OnSelectionChanged(func(id gxui.AdapterItemId) {
-		if id != gxui.InvalidAdapterItemId {
-			selected.SetBackgroundBrush(list.Item(id).(gxui.Image).BackgroundBrush())
+	list.OnSelectionChanged(func(item gxui.AdapterItem) {
+		if item != nil {
+			control := list.ItemControl(item)
+			selected.SetBackgroundBrush(control.(gxui.Image).BackgroundBrush())
 		}
 	})
 

--- a/samples/polyedit/main.go
+++ b/samples/polyedit/main.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/google/gxui"
@@ -162,6 +161,5 @@ func appMain(driver gxui.Driver) {
 }
 
 func main() {
-	flag.Parse()
 	gl.StartDriver(appMain)
 }

--- a/samples/tree/main.go
+++ b/samples/tree/main.go
@@ -13,24 +13,23 @@ import (
 
 type treeAdapterNode struct {
 	children []treeAdapterNode
-	data     string
-	id       gxui.AdapterItemId
+	item     string
 }
 
 func (n treeAdapterNode) Count() int {
 	return len(n.children)
 }
 
-func (n treeAdapterNode) ItemId(index int) gxui.AdapterItemId {
-	return n.children[index].id
+func (n treeAdapterNode) ItemAt(index int) gxui.AdapterItem {
+	return n.children[index].item
 }
 
-func (n treeAdapterNode) ItemIndex(id gxui.AdapterItemId) int {
+func (n treeAdapterNode) ItemIndex(item gxui.AdapterItem) int {
 	for i, c := range n.children {
-		if c.id == id {
+		if c.item == item {
 			return i
 		}
-		if c.ItemIndex(id) >= 0 {
+		if c.ItemIndex(item) >= 0 {
 			return i
 		}
 	}
@@ -39,7 +38,7 @@ func (n treeAdapterNode) ItemIndex(id gxui.AdapterItemId) int {
 
 func (n treeAdapterNode) Create(theme gxui.Theme, index int) gxui.Control {
 	l := theme.CreateLabel()
-	l.SetText(n.children[index].data)
+	l.SetText(n.children[index].item)
 	return l
 }
 
@@ -78,11 +77,10 @@ func (a treeAdapter) OnDataReplaced(f func()) gxui.EventSubscription {
 func appMain(driver gxui.Driver) {
 	theme := dark.CreateTheme(driver)
 
-	node := func(id gxui.AdapterItemId, data string, children ...treeAdapterNode) treeAdapterNode {
+	node := func(item string, children ...treeAdapterNode) treeAdapterNode {
 		return treeAdapterNode{
 			children: children,
-			data:     data,
-			id:       id,
+			item:     item,
 		}
 	}
 
@@ -91,39 +89,39 @@ func appMain(driver gxui.Driver) {
 
 	adapter := treeAdapter{}
 	adapter.children = []treeAdapterNode{
-		node(0x000, "Animals",
-			node(0x100, "Mammals",
-				node(0x110, "Cats"),
-				node(0x120, "Dogs"),
-				node(0x130, "Horses"),
-				node(0x140, "Duck-billed platypuses"),
+		node("Animals",
+			node("Mammals",
+				node("Cats"),
+				node("Dogs"),
+				node("Horses"),
+				node("Duck-billed platypuses"),
 			),
-			node(0x200, "Birds",
-				node(0x210, "Peacocks"),
-				node(0x220, "Doves"),
+			node("Birds",
+				node("Peacocks"),
+				node("Doves"),
 			),
-			node(0x300, "Reptiles",
-				node(0x310, "Lizards"),
-				node(0x320, "Turtles"),
-				node(0x330, "Crocodiles"),
-				node(0x340, "Snakes"),
+			node("Reptiles",
+				node("Lizards"),
+				node("Turtles"),
+				node("Crocodiles"),
+				node("Snakes"),
 			),
-			node(0x400, "Amphibians",
-				node(0x410, "Frogs"),
-				node(0x420, "Toads"),
+			node("Amphibians",
+				node("Frogs"),
+				node("Toads"),
 			),
-			node(0x500, "Arthropods",
-				node(0x510, "Crustaceans",
-					node(0x511, "Crabs"),
-					node(0x512, "Lobsters"),
+			node("Arthropods",
+				node("Crustaceans",
+					node("Crabs"),
+					node("Lobsters"),
 				),
-				node(0x520, "Insects",
-					node(0x521, "Ants"),
-					node(0x522, "Bees"),
+				node("Insects",
+					node("Ants"),
+					node("Bees"),
 				),
-				node(0x530, "Arachnids",
-					node(0x531, "Spiders"),
-					node(0x532, "Scorpions"),
+				node("Arachnids",
+					node("Spiders"),
+					node("Scorpions"),
 				),
 			),
 		),
@@ -131,7 +129,7 @@ func appMain(driver gxui.Driver) {
 
 	tree := theme.CreateTree()
 	tree.SetAdapter(adapter)
-	tree.Select(0x140) // Duck-billed platypuses
+	tree.Select("Duck-billed platypuses")
 	tree.Show(tree.Selected())
 
 	layout.AddChild(tree)

--- a/samples/tree/main.go
+++ b/samples/tree/main.go
@@ -56,7 +56,7 @@ type treeAdapter struct {
 	onDataReplaced gxui.Event
 }
 
-func (a treeAdapter) ItemSize(theme gxui.Theme) math.Size {
+func (a treeAdapter) Size(theme gxui.Theme) math.Size {
 	return math.Size{W: math.MaxSize.W, H: 20}
 }
 

--- a/tree.go
+++ b/tree.go
@@ -9,9 +9,8 @@ type Tree interface {
 	SetAdapter(TreeAdapter)
 	Adapter() TreeAdapter
 
-	// Show makes the item with the specified id visible, expanding the tree if
-	// necessary.
-	Show(AdapterItemId)
+	// Show makes the specifieditem visible, expanding the tree if necessary.
+	Show(AdapterItem)
 
 	// ExpandAll expands all tree nodes.
 	ExpandAll()
@@ -19,7 +18,7 @@ type Tree interface {
 	// CollapseAll collapses all tree nodes.
 	CollapseAll()
 
-	Selected() AdapterItemId
-	Select(AdapterItemId)
-	OnSelectionChanged(func(AdapterItemId)) EventSubscription
+	Selected() AdapterItem
+	Select(AdapterItem)
+	OnSelectionChanged(func(AdapterItem)) EventSubscription
 }

--- a/tree_adapter.go
+++ b/tree_adapter.go
@@ -10,8 +10,8 @@ import (
 
 type TreeAdapterNode interface {
 	Count() int
-	ItemId(index int) AdapterItemId
-	ItemIndex(id AdapterItemId) int
+	ItemAt(index int) AdapterItem
+	ItemIndex(item AdapterItem) int
 	Create(theme Theme, index int) Control
 	CreateNode(index int) TreeAdapterNode
 }

--- a/tree_adapter.go
+++ b/tree_adapter.go
@@ -4,9 +4,7 @@
 
 package gxui
 
-import (
-	"github.com/google/gxui/math"
-)
+import "github.com/google/gxui/math"
 
 type TreeAdapterNode interface {
 	Count() int
@@ -18,7 +16,7 @@ type TreeAdapterNode interface {
 
 type TreeAdapter interface {
 	TreeAdapterNode
-	ItemSize(theme Theme) math.Size
+	Size(Theme) math.Size
 	OnDataChanged(func()) EventSubscription
 	OnDataReplaced(func()) EventSubscription
 }


### PR DESCRIPTION
* Document the Adapter interface.
* Replace AdapterItemIds with AdapterItems.
* Rename ItemSize with Size to avoiding confusing overload of 'item'
