### PR TITLE
Remove unused origin parameter from DrawRunes

### DIFF
--- a/canvas.go
+++ b/canvas.go
@@ -17,7 +17,7 @@ type Canvas interface {
 	Clear(Color)
 	DrawCanvas(c Canvas, position math.Point)
 	DrawTexture(t Texture, bounds math.Rect)
-	DrawRunes(font Font, runes []rune, color Color, points []math.Point, origin math.Point)
+	DrawRunes(font Font, runes []rune, points []math.Point, color Color)
 	DrawLines(Polygon, Pen)
 	DrawPolygon(Polygon, Pen, Brush)
 	DrawRect(math.Rect, Brush)

--- a/drivers/gl/canvas.go
+++ b/drivers/gl/canvas.go
@@ -145,14 +145,14 @@ func (c *Canvas) DrawCanvas(canvas gxui.Canvas, offsetDips math.Point) {
 	c.appendResource(childCanvas)
 }
 
-func (c *Canvas) DrawRunes(f gxui.Font, r []rune, col gxui.Color, p []math.Point, o math.Point) {
+func (c *Canvas) DrawRunes(f gxui.Font, r []rune, p []math.Point, col gxui.Color) {
 	if f == nil {
 		panic("Font cannot be nil")
 	}
 	runes := append([]rune{}, r...)
 	points := append([]math.Point{}, p...)
 	c.appendOp("DrawRunes", func(ctx *Context, dss *DrawStateStack) {
-		f.(*Font).DrawRunes(ctx, runes, col, points, o, dss.Head())
+		f.(*Font).DrawRunes(ctx, runes, points, col, dss.Head())
 	})
 }
 

--- a/drivers/gl/font.go
+++ b/drivers/gl/font.go
@@ -101,7 +101,7 @@ func (f *Font) align(rect math.Rect, size math.Size, ascent int, h gxui.Horizont
 	return origin
 }
 
-func (f *Font) DrawRunes(ctx *Context, runes []rune, col gxui.Color, offsets []math.Point, origin math.Point, ds *DrawState) {
+func (f *Font) DrawRunes(ctx *Context, runes []rune, offsets []math.Point, col gxui.Color, ds *DrawState) {
 	if len(runes) != len(offsets) {
 		panic(fmt.Errorf("There must be the same number of runes to offsets. Got %d runes and %d offsets",
 			len(runes), len(offsets)))
@@ -117,9 +117,7 @@ func (f *Font) DrawRunes(ctx *Context, runes []rune, col gxui.Color, offsets []m
 		page := table.get(r, glyph)
 		texture := page.texture()
 		srcRect := glyph.size(resolution).Rect().Offset(page.offset(r))
-		dstRect := glyph.rect(resolution).
-			Offset(resolution.PointDipsToPixels(offsets[i])).
-			Offset(origin)
+		dstRect := glyph.rect(resolution).Offset(resolution.PointDipsToPixels(offsets[i]))
 		tc := ctx.GetOrCreateTextureContext(texture)
 		ctx.Blitter.BlitGlyph(ctx, tc, col, srcRect, dstRect, ds)
 	}

--- a/mixins/code_editor_line.go
+++ b/mixins/code_editor_line.go
@@ -70,7 +70,7 @@ func (t *CodeEditorLine) PaintGlyphs(c gxui.Canvas, info CodeEditorLinePaintInfo
 			for _, span := range l.Spans().Overlaps(info.LineSpan) {
 				interval.Visit(&remaining, span, func(vs, ve uint64, _ int) {
 					s, e := vs-start, ve-start
-					c.DrawRunes(font, runes[s:e], color, offsets[s:e], math.Point{})
+					c.DrawRunes(font, runes[s:e], offsets[s:e], color)
 				})
 				interval.Remove(&remaining, span)
 			}
@@ -79,7 +79,7 @@ func (t *CodeEditorLine) PaintGlyphs(c gxui.Canvas, info CodeEditorLinePaintInfo
 	for _, span := range remaining {
 		s, e := span.Span()
 		s, e = s-start, e-start
-		c.DrawRunes(font, runes[s:e], t.ce.textColor, offsets[s:e], math.Point{})
+		c.DrawRunes(font, runes[s:e], offsets[s:e], t.ce.textColor)
 	}
 }
 

--- a/mixins/default_textbox_line.go
+++ b/mixins/default_textbox_line.go
@@ -83,7 +83,7 @@ func (t *DefaultTextBoxLine) PaintText(c gxui.Canvas) {
 		H:         gxui.AlignLeft,
 		V:         gxui.AlignBottom,
 	})
-	c.DrawRunes(f, runes, t.textbox.textColor, offsets, math.Point{})
+	c.DrawRunes(f, runes, offsets, t.textbox.textColor)
 }
 
 func (t *DefaultTextBoxLine) PaintCarets(c gxui.Canvas) {

--- a/mixins/label.go
+++ b/mixins/label.go
@@ -121,6 +121,5 @@ func (l *Label) Paint(c gxui.Canvas) {
 		H:         l.horizontalAlignment,
 		V:         l.verticalAlignment,
 	})
-	origin := math.Point{}
-	c.DrawRunes(l.font, runes, l.color, offsets, origin)
+	c.DrawRunes(l.font, runes, offsets, l.color)
 }


### PR DESCRIPTION
Every argument was a zero point.
Also move the point list next to the rune list - it was weird that they were apart.