### PR TITLE
Use TravisCI for continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+sudo: false
+
+language: go
+
+addons:
+  apt_packages:
+    - libxi-dev
+    - libxcursor-dev
+    - libxrandr-dev
+    - libxinerama-dev
+    - mesa-common-dev
+    - libgl1-mesa-dev
+    - libxxf86vm-dev
+
+go:
+  - 1.4
+  - tip
+
+install:
+  - go get code.google.com/p/freetype-go/freetype
+  - go get github.com/go-gl/gl/v2.1/gl
+  - go get github.com/go-gl/glfw/v3.1/glfw
+
+script: go test -v ./...


### PR DESCRIPTION
Resolves #73 

Example output: https://travis-ci.org/andrewseidl/gxui/jobs/56396324

I also had to apt-get `libxxf86vm-dev`, which is required by `github.com/go-gl/glfw/v3.1/glfw`. Will submit a separate PR to update `README.md`.