### PR TITLE
readme: add libxxf86vm-dev to Linux dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Dependencies
 
 In order to build GXUI on linux, you will need the following packages installed:
 
-    sudo apt-get install libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgl1-mesa-dev
+    sudo apt-get install libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgl1-mesa-dev libxxf86vm-dev
 
 ### Common:
 


### PR DESCRIPTION
Required by `github.com/go-gl/glfw/v3.1/glfw`