### PR TITLE
drivers/gl: Use github.com/goxjs/gl instead of github.com/go-gl/gl/v2.1/gl.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,14 @@
-sudo: false
-
 language: go
-
-addons:
-  apt_packages:
-    - libxi-dev
-    - libxcursor-dev
-    - libxrandr-dev
-    - libxinerama-dev
-    - mesa-common-dev
-    - libgl1-mesa-dev
-    - libxxf86vm-dev
-
 go:
   - 1.4
   - tip
-
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install -qq libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgles2-mesa-dev libxxf86vm-dev
 install:
-  - go get code.google.com/p/freetype-go/freetype
-  - go get github.com/go-gl/gl/v2.1/gl
-  - go get github.com/go-gl/glfw/v3.1/glfw
-
-script: go test -v ./...
+  - go get golang.org/x/tools/cmd/vet
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d ./)
+  - go tool vet -composites=false ./
+  - go test -v -race ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
   - tip
 before_install:
   - sudo apt-get update
-  - sudo apt-get install -qq libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgles2-mesa-dev libxxf86vm-dev
+  - sudo apt-get install -qq libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgl1-mesa-dev libxxf86vm-dev
 install:
   - go get golang.org/x/tools/cmd/vet
 script:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Dependencies
 
 In order to build GXUI on linux, you will need the following packages installed:
 
-    sudo apt-get install libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgles2-mesa-dev libxxf86vm-dev
+    sudo apt-get install libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgl1-mesa-dev libxxf86vm-dev
 
 ### Common:
 

--- a/README.md
+++ b/README.md
@@ -19,24 +19,17 @@ Dependencies
 
 In order to build GXUI on linux, you will need the following packages installed:
 
-    sudo apt-get install libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgl1-mesa-dev libxxf86vm-dev
+    sudo apt-get install libxi-dev libxcursor-dev libxrandr-dev libxinerama-dev mesa-common-dev libgles2-mesa-dev libxxf86vm-dev
 
 ### Common:
 
-After setting up ```GOPATH``` (see [Go documentation](https://golang.org/doc/code.html)), you will first need to fetch the required dependencies:
+After setting up ```GOPATH``` (see [Go documentation](https://golang.org/doc/code.html)), you can then fetch the GXUI library and its dependencies:
 
-    go get code.google.com/p/freetype-go/freetype
-    go get github.com/go-gl/gl/v2.1/gl
-    go get github.com/go-gl/glfw/v3.1/glfw
-
-
-Once these have been fetched, you can then fetch the GXUI library:
-
-    go get github.com/google/gxui
+    go get -u github.com/google/gxui/...
 
 Samples
 ---
-Samples can be found in [`gxui/samples`](https://github.com/google/gxui/tree/master/samples). 
+Samples can be found in [`gxui/samples`](https://github.com/google/gxui/tree/master/samples).
 
 To build all samples run:
 
@@ -44,7 +37,7 @@ To build all samples run:
 
 And they will be built into ```GOPATH/bin```.
 
-If you add ```GOPATH/bin``` to your PATH, you can simply type the name of a sample to run it. For example: ```image_viewer```. 
+If you add ```GOPATH/bin``` to your PATH, you can simply type the name of a sample to run it. For example: ```image_viewer```.
 
 Fonts
 ---

--- a/debug.go
+++ b/debug.go
@@ -23,7 +23,7 @@ func dump(c interface{}, depth int) string {
 	s := ""
 	switch t := c.(type) {
 	case Control:
-		s += fmt.Sprintf("(%p) %T Size: %+v Margin: %+v \n", t, t, t.Size(), t.Margin())
+		s += fmt.Sprintf("(%p) %T Size: %+v Margin: %+v \n", &t, t, t.Size(), t.Margin())
 	default:
 		s += fmt.Sprintf("%T\n", t)
 	}

--- a/drivers/gl/blitter.go
+++ b/drivers/gl/blitter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/gxui"
 	"github.com/google/gxui/math"
 
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 const (

--- a/drivers/gl/blitter.go
+++ b/drivers/gl/blitter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/gxui"
 	"github.com/google/gxui/math"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"golang.org/x/mobile/gl"
 )
 
 const (
@@ -20,12 +20,16 @@ const (
   uniform mat3 mPos;
   uniform mat3 mUV;
   void main() {
-  	vec3 pos3 = vec3(aPosition, 1.0);
+    vec3 pos3 = vec3(aPosition, 1.0);
     gl_Position = vec4(mPos * pos3, 1.0);
     vTexcoords = (mUV * pos3).xy;
   }`
 
 	fsCopySrc = `
+  #ifdef GL_ES
+    precision mediump float;
+  #endif
+
   uniform sampler2D source;
   varying vec2 vTexcoords;
   void main() {
@@ -36,11 +40,15 @@ const (
   attribute vec2 aPosition;
   uniform mat3 mPos;
   void main() {
-  	vec3 pos3 = vec3(aPosition, 1.0);
+    vec3 pos3 = vec3(aPosition, 1.0);
     gl_Position = vec4((mPos * pos3).xy, 0.0, 1.0);
   }`
 
 	fsColorSrc = `
+  #ifdef GL_ES
+    precision mediump float;
+  #endif
+
   uniform vec4 Color;
   void main() {
     gl_FragColor = Color;
@@ -67,6 +75,10 @@ const (
   }`
 
 	fsFontSrc = `
+  #ifdef GL_ES
+    precision mediump float;
+  #endif
+
   uniform sampler2D source;
   varying vec2 vSrc;
   varying vec4 vCol;
@@ -83,7 +95,7 @@ type glyphBatch struct {
 	SrcRects  []float32
 	Colors    []float32
 	ClipRects []float32
-	Indices   []uint32
+	Indices   []uint16
 	GlyphPage *textureContext
 }
 
@@ -163,7 +175,7 @@ func (b *blitter) blitGlyph(ctx *context, tc *textureContext, c gxui.Color, srcR
 		b.commitGlyphs(ctx)
 		b.glyphBatch.GlyphPage = tc
 	}
-	i := uint32(len(b.glyphBatch.DstRects)) / 2
+	i := uint16(len(b.glyphBatch.DstRects)) / 2
 	clip := []float32{
 		float32(ds.ClipPixels.Min.X),
 		float32(ds.ClipPixels.Min.Y),
@@ -219,12 +231,13 @@ func (b *blitter) blitShape(ctx *context, shape shape, color gxui.Color, ds *dra
 	})
 
 	if debugWireframePolygons {
-		gl.PolygonMode(gl.FRONT_AND_BACK, gl.LINE)
+		// glPolygonMode is not available in OpenGL ES/WebGL (since its implementation is very inefficient; a shame because it's useful for debugging).
+		//gl.PolygonMode(gl.FRONT_AND_BACK, gl.LINE)
 		shape.draw(ctx, b.colorShader, uniformBindings{
 			"mPos":  mPos,
 			"Color": gxui.Blue,
 		})
-		gl.PolygonMode(gl.FRONT_AND_BACK, gl.FILL)
+		//gl.PolygonMode(gl.FRONT_AND_BACK, gl.FILL)
 	}
 	b.stats.drawCallCount++
 }
@@ -275,7 +288,7 @@ func (b *blitter) commitGlyphs(ctx *context) {
 		newVertexStream("aClp", stFloatVec4, b.glyphBatch.ClipRects),
 		newVertexStream("aCol", stFloatVec4, b.glyphBatch.Colors),
 	)
-	ib := newIndexBuffer(ptUint, b.glyphBatch.Indices)
+	ib := newIndexBuffer(ptUshort, b.glyphBatch.Indices)
 	s := newShape(vb, ib, dmTriangles)
 	gl.Disable(gl.SCISSOR_TEST)
 	s.draw(ctx, b.fontShader, uniformBindings{

--- a/drivers/gl/canvas.go
+++ b/drivers/gl/canvas.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/gxui"
 	"github.com/google/gxui/math"
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type drawStateStack []drawState

--- a/drivers/gl/canvas.go
+++ b/drivers/gl/canvas.go
@@ -7,9 +7,9 @@ package gl
 import (
 	"fmt"
 
-	"github.com/go-gl/gl/v2.1/gl"
 	"github.com/google/gxui"
 	"github.com/google/gxui/math"
+	"golang.org/x/mobile/gl"
 )
 
 type drawStateStack []drawState

--- a/drivers/gl/check_error.go
+++ b/drivers/gl/check_error.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"fmt"
 
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 func checkError() {

--- a/drivers/gl/check_error.go
+++ b/drivers/gl/check_error.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"fmt"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"golang.org/x/mobile/gl"
 )
 
 func checkError() {
@@ -17,8 +17,6 @@ func checkError() {
 			panic("GL returned error GL_INVALID_ENUM")
 		case gl.INVALID_FRAMEBUFFER_OPERATION:
 			panic("GL returned error GL_INVALID_FRAMEBUFFER_OPERATION")
-		case gl.INVALID_INDEX:
-			panic("GL returned error GL_INVALID_INDEX")
 		case gl.INVALID_OPERATION:
 			panic("GL returned error GL_INVALID_OPERATION")
 		case gl.INVALID_VALUE:

--- a/drivers/gl/context.go
+++ b/drivers/gl/context.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"github.com/google/gxui/math"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"golang.org/x/mobile/gl"
 )
 
 type context struct {

--- a/drivers/gl/context.go
+++ b/drivers/gl/context.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"github.com/google/gxui/math"
 
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type context struct {

--- a/drivers/gl/draw_mode.go
+++ b/drivers/gl/draw_mode.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"fmt"
 
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type drawMode int

--- a/drivers/gl/draw_mode.go
+++ b/drivers/gl/draw_mode.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"fmt"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"golang.org/x/mobile/gl"
 )
 
 type drawMode int

--- a/drivers/gl/index_buffer.go
+++ b/drivers/gl/index_buffer.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type indexBuffer struct {

--- a/drivers/gl/primitive_type.go
+++ b/drivers/gl/primitive_type.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type primitiveType int

--- a/drivers/gl/primitive_type.go
+++ b/drivers/gl/primitive_type.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"golang.org/x/mobile/gl"
 )
 
 type primitiveType int

--- a/drivers/gl/shader_attribute.go
+++ b/drivers/gl/shader_attribute.go
@@ -4,7 +4,7 @@
 
 package gl
 
-import "golang.org/x/mobile/gl"
+import "github.com/goxjs/gl"
 
 type shaderAttribute struct {
 	name     string

--- a/drivers/gl/shader_attribute.go
+++ b/drivers/gl/shader_attribute.go
@@ -4,13 +4,13 @@
 
 package gl
 
-import "github.com/go-gl/gl/v2.1/gl"
+import "golang.org/x/mobile/gl"
 
 type shaderAttribute struct {
 	name     string
 	size     int
 	ty       shaderDataType
-	location uint32
+	location gl.Attrib
 }
 
 func (a shaderAttribute) enableArray() {
@@ -21,6 +21,6 @@ func (a shaderAttribute) disableArray() {
 	gl.DisableVertexAttribArray(a.location)
 }
 
-func (a shaderAttribute) attribPointer(size int32, ty uint32, normalized bool, stride int32, data interface{}) {
-	gl.VertexAttribPointer(a.location, size, ty, normalized, stride, gl.Ptr(data))
+func (a shaderAttribute) attribPointer(size int32, ty uint32, normalized bool, stride int32, offset int) {
+	gl.VertexAttribPointer(a.location, int(size), gl.Enum(ty), normalized, int(stride), offset)
 }

--- a/drivers/gl/shader_data_type.go
+++ b/drivers/gl/shader_data_type.go
@@ -7,46 +7,28 @@ package gl
 import (
 	"fmt"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"golang.org/x/mobile/gl"
 )
 
 type shaderDataType int
 
 const (
-	stFloatMat2x3 shaderDataType = gl.FLOAT_MAT2x3
-	stFloatMat2x4 shaderDataType = gl.FLOAT_MAT2x4
-	stFloatMat2   shaderDataType = gl.FLOAT_MAT2
-	stFloatMat3x2 shaderDataType = gl.FLOAT_MAT3x2
-	stFloatMat3x4 shaderDataType = gl.FLOAT_MAT3x4
-	stFloatMat3   shaderDataType = gl.FLOAT_MAT3
-	stFloatMat4x2 shaderDataType = gl.FLOAT_MAT4x2
-	stFloatMat4x3 shaderDataType = gl.FLOAT_MAT4x3
-	stFloatMat4   shaderDataType = gl.FLOAT_MAT4
-	stFloatVec1   shaderDataType = gl.FLOAT
-	stFloatVec2   shaderDataType = gl.FLOAT_VEC2
-	stFloatVec3   shaderDataType = gl.FLOAT_VEC3
-	stFloatVec4   shaderDataType = gl.FLOAT_VEC4
-	stSampler2d   shaderDataType = gl.SAMPLER_2D
+	stFloatMat2 shaderDataType = gl.FLOAT_MAT2
+	stFloatMat3 shaderDataType = gl.FLOAT_MAT3
+	stFloatMat4 shaderDataType = gl.FLOAT_MAT4
+	stFloatVec1 shaderDataType = gl.FLOAT
+	stFloatVec2 shaderDataType = gl.FLOAT_VEC2
+	stFloatVec3 shaderDataType = gl.FLOAT_VEC3
+	stFloatVec4 shaderDataType = gl.FLOAT_VEC4
+	stSampler2d shaderDataType = gl.SAMPLER_2D
 )
 
 func (s shaderDataType) String() string {
 	switch s {
-	case stFloatMat2x3:
-		return "mat2x3"
-	case stFloatMat2x4:
-		return "mat2x4"
 	case stFloatMat2:
 		return "mat2"
-	case stFloatMat3x2:
-		return "mat3x2"
-	case stFloatMat3x4:
-		return "mat3x4"
 	case stFloatMat3:
 		return "mat3"
-	case stFloatMat4x2:
-		return "mat4x2"
-	case stFloatMat4x3:
-		return "mat4x3"
 	case stFloatMat4:
 		return "mat4"
 	case stFloatVec1:
@@ -70,22 +52,10 @@ func (s shaderDataType) sizeInBytes() int {
 
 func (s shaderDataType) vectorElementCount() int {
 	switch s {
-	case stFloatMat2x3:
-		return 2 * 3
-	case stFloatMat2x4:
-		return 2 * 4
 	case stFloatMat2:
 		return 2 * 2
-	case stFloatMat3x2:
-		return 3 * 2
-	case stFloatMat3x4:
-		return 3 * 4
 	case stFloatMat3:
 		return 3 * 3
-	case stFloatMat4x2:
-		return 4 * 2
-	case stFloatMat4x3:
-		return 4 * 3
 	case stFloatMat4:
 		return 4 * 4
 	case stFloatVec1:
@@ -105,21 +75,9 @@ func (s shaderDataType) vectorElementCount() int {
 
 func (s shaderDataType) vectorElementType() primitiveType {
 	switch s {
-	case stFloatMat2x3:
-		return ptFloat
-	case stFloatMat2x4:
-		return ptFloat
 	case stFloatMat2:
 		return ptFloat
-	case stFloatMat3x2:
-		return ptFloat
-	case stFloatMat3x4:
-		return ptFloat
 	case stFloatMat3:
-		return ptFloat
-	case stFloatMat4x2:
-		return ptFloat
-	case stFloatMat4x3:
 		return ptFloat
 	case stFloatMat4:
 		return ptFloat

--- a/drivers/gl/shader_data_type.go
+++ b/drivers/gl/shader_data_type.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"fmt"
 
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type shaderDataType int

--- a/drivers/gl/shader_program.go
+++ b/drivers/gl/shader_program.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"fmt"
 
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type uniformBindings map[string]interface{}

--- a/drivers/gl/shader_uniform.go
+++ b/drivers/gl/shader_uniform.go
@@ -7,89 +7,76 @@ package gl
 import (
 	"fmt"
 
-	"github.com/go-gl/gl/v2.1/gl"
 	"github.com/google/gxui"
 	"github.com/google/gxui/math"
+	"golang.org/x/mobile/gl"
 )
 
 type shaderUniform struct {
 	name        string
 	size        int
 	ty          shaderDataType
-	location    int32
+	location    gl.Uniform
 	textureUnit int
 }
 
 func (u *shaderUniform) bind(context *context, v interface{}) {
-	transpose := false
 	switch u.ty {
-	case stFloatMat2x3:
-		gl.UniformMatrix2x3fv(u.location, 1, transpose, &v.([]float32)[0])
-	case stFloatMat2x4:
-		gl.UniformMatrix2x4fv(u.location, 1, transpose, &v.([]float32)[0])
 	case stFloatMat2:
-		gl.UniformMatrix2fv(u.location, 1, transpose, &v.([]float32)[0])
-	case stFloatMat3x2:
-		gl.UniformMatrix3x2fv(u.location, 1, transpose, &v.([]float32)[0])
-	case stFloatMat3x4:
-		gl.UniformMatrix3x4fv(u.location, 1, transpose, &v.([]float32)[0])
+		gl.UniformMatrix2fv(u.location, v.([]float32))
 	case stFloatMat3:
 		switch m := v.(type) {
 		case math.Mat3:
-			gl.UniformMatrix3fv(u.location, 1, transpose, &m[0])
+			gl.UniformMatrix3fv(u.location, m[:])
 		case []float32:
-			gl.UniformMatrix3fv(u.location, 1, transpose, &m[0])
+			gl.UniformMatrix3fv(u.location, m)
 		}
-	case stFloatMat4x2:
-		gl.UniformMatrix4x2fv(u.location, 1, transpose, &v.([]float32)[0])
-	case stFloatMat4x3:
-		gl.UniformMatrix4x3fv(u.location, 1, transpose, &v.([]float32)[0])
 	case stFloatMat4:
-		gl.UniformMatrix4fv(u.location, 1, transpose, &v.([]float32)[0])
+		gl.UniformMatrix4fv(u.location, v.([]float32))
 	case stFloatVec1:
 		switch v := v.(type) {
 		case float32:
 			gl.Uniform1f(u.location, v)
 		case []float32:
-			gl.Uniform1fv(u.location, int32(len(v)), &v[0])
+			gl.Uniform1fv(u.location, v)
 		}
 	case stFloatVec2:
 		switch v := v.(type) {
 		case math.Vec2:
-			gl.Uniform2fv(u.location, 1, &[]float32{v.X, v.Y}[0])
+			gl.Uniform2fv(u.location, []float32{v.X, v.Y})
 		case []float32:
 			if len(v)%2 != 0 {
 				panic(fmt.Errorf("Uniform '%s' of type vec2 should be an float32 array with a multiple of two length", u.name))
 			}
-			gl.Uniform2fv(u.location, int32(len(v)/2), &v[0])
+			gl.Uniform2fv(u.location, v)
 		}
 	case stFloatVec3:
 		switch v := v.(type) {
 		case math.Vec3:
-			gl.Uniform3fv(u.location, 1, &[]float32{v.X, v.Y, v.Z}[0])
+			gl.Uniform3fv(u.location, []float32{v.X, v.Y, v.Z})
 		case []float32:
 			if len(v)%3 != 0 {
 				panic(fmt.Errorf("Uniform '%s' of type vec3 should be an float32 array with a multiple of three length", u.name))
 			}
-			gl.Uniform3fv(u.location, int32(len(v)/3), &v[0])
+			gl.Uniform3fv(u.location, v)
 		}
 	case stFloatVec4:
 		switch v := v.(type) {
 		case math.Vec4:
-			gl.Uniform4fv(u.location, 1, &[]float32{v.X, v.Y, v.Z, v.W}[0])
+			gl.Uniform4fv(u.location, []float32{v.X, v.Y, v.Z, v.W})
 		case gxui.Color:
-			gl.Uniform4fv(u.location, 1, &[]float32{v.R, v.G, v.B, v.A}[0])
+			gl.Uniform4fv(u.location, []float32{v.R, v.G, v.B, v.A})
 		case []float32:
 			if len(v)%4 != 0 {
 				panic(fmt.Errorf("Uniform '%s' of type vec4 should be an float32 array with a multiple of four length", u.name))
 			}
-			gl.Uniform4fv(u.location, int32(len(v)/4), &v[0])
+			gl.Uniform4fv(u.location, v)
 		}
 	case stSampler2d:
 		tc := v.(*textureContext)
-		gl.ActiveTexture(gl.TEXTURE0 + uint32(u.textureUnit))
+		gl.ActiveTexture(gl.Enum(gl.TEXTURE0 + u.textureUnit))
 		gl.BindTexture(gl.TEXTURE_2D, tc.texture)
-		gl.Uniform1i(u.location, int32(u.textureUnit))
+		gl.Uniform1i(u.location, u.textureUnit)
 	default:
 		panic(fmt.Errorf("Uniform of unsupported type %s", u.ty))
 	}

--- a/drivers/gl/shader_uniform.go
+++ b/drivers/gl/shader_uniform.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/gxui"
 	"github.com/google/gxui/math"
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type shaderUniform struct {

--- a/drivers/gl/shape.go
+++ b/drivers/gl/shape.go
@@ -4,7 +4,7 @@
 
 package gl
 
-import "golang.org/x/mobile/gl"
+import "github.com/goxjs/gl"
 
 type shape struct {
 	refCounted

--- a/drivers/gl/shape.go
+++ b/drivers/gl/shape.go
@@ -4,7 +4,7 @@
 
 package gl
 
-import "github.com/go-gl/gl/v2.1/gl"
+import "golang.org/x/mobile/gl"
 
 type shape struct {
 	refCounted
@@ -52,7 +52,7 @@ func newQuadShape() *shape {
 		1.0, 1.0,
 	})
 	vb := newVertexBuffer(pos)
-	ib := newIndexBuffer(ptUint, []uint32{
+	ib := newIndexBuffer(ptUshort, []uint16{
 		0, 1, 2,
 		2, 1, 3,
 	})
@@ -66,7 +66,7 @@ func (s shape) draw(ctx *context, shader *shaderProgram, ub uniformBindings) {
 	if s.ib != nil {
 		ctx.getOrCreateIndexBufferContext(s.ib).render(s.drawMode)
 	} else {
-		gl.DrawArrays(uint32(s.drawMode), 0, int32(s.vb.count))
+		gl.DrawArrays(gl.Enum(s.drawMode), 0, s.vb.count)
 	}
 	shader.unbind(ctx)
 	checkError()

--- a/drivers/gl/texture.go
+++ b/drivers/gl/texture.go
@@ -8,7 +8,7 @@ import (
 	"image"
 
 	"github.com/google/gxui/math"
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 type texture struct {

--- a/drivers/gl/texture.go
+++ b/drivers/gl/texture.go
@@ -5,10 +5,10 @@
 package gl
 
 import (
-	"github.com/google/gxui/math"
 	"image"
 
-	"github.com/go-gl/gl/v2.1/gl"
+	"github.com/google/gxui/math"
+	"golang.org/x/mobile/gl"
 )
 
 type texture struct {
@@ -54,8 +54,8 @@ func (t *texture) Release() {
 }
 
 func (t *texture) newContext() *textureContext {
-	var fmt uint32
-	var data interface{}
+	var fmt gl.Enum
+	var data []byte
 	var pma bool
 
 	switch ty := t.image.(type) {
@@ -66,9 +66,6 @@ func (t *texture) newContext() *textureContext {
 	case *image.NRGBA:
 		fmt = gl.RGBA
 		data = ty.Pix
-	case *image.Gray:
-		fmt = gl.RED
-		data = ty.Pix
 	case *image.Alpha:
 		fmt = gl.ALPHA
 		data = ty.Pix
@@ -76,14 +73,13 @@ func (t *texture) newContext() *textureContext {
 		panic("Unsupported image type")
 	}
 
-	var texture uint32
-	gl.GenTextures(1, &texture)
+	texture := gl.CreateTexture()
 	gl.BindTexture(gl.TEXTURE_2D, texture)
 	w, h := t.SizePixels().WH()
-	gl.TexImage2D(gl.TEXTURE_2D, 0, int32(fmt), int32(w), int32(h), 0, fmt, gl.UNSIGNED_BYTE, gl.Ptr(data))
+	gl.TexImage2D(gl.TEXTURE_2D, 0, w, h, fmt, gl.UNSIGNED_BYTE, data)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
 	gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
-	gl.BindTexture(gl.TEXTURE_2D, 0)
+	gl.BindTexture(gl.TEXTURE_2D, gl.Texture{})
 	checkError()
 
 	return &textureContext{
@@ -95,13 +91,13 @@ func (t *texture) newContext() *textureContext {
 }
 
 type textureContext struct {
-	texture    uint32
+	texture    gl.Texture
 	sizePixels math.Size
 	flipY      bool
 	pma        bool
 }
 
 func (c *textureContext) destroy() {
-	gl.DeleteTextures(1, &c.texture)
-	c.texture = 0
+	gl.DeleteTexture(c.texture)
+	c.texture = gl.Texture{}
 }

--- a/drivers/gl/vertex_stream.go
+++ b/drivers/gl/vertex_stream.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/goxjs/gl"
 	"golang.org/x/mobile/f32"
-	"golang.org/x/mobile/gl"
 )
 
 type vertexStream struct {

--- a/drivers/gl/vertex_stream.go
+++ b/drivers/gl/vertex_stream.go
@@ -5,12 +5,11 @@
 package gl
 
 import (
-	"encoding/binary"
 	"fmt"
+	"math"
 	"reflect"
 
 	"github.com/goxjs/gl"
-	"golang.org/x/mobile/f32"
 )
 
 type vertexStream struct {
@@ -38,7 +37,7 @@ func newVertexStream(name string, ty shaderDataType, data32 []float32) *vertexSt
 	}
 
 	// HACK.
-	data := f32.Bytes(binary.LittleEndian, data32...)
+	data := float32Bytes(data32...)
 
 	vs := &vertexStream{
 		name:  name,
@@ -76,4 +75,17 @@ func (c vertexStreamContext) bind() {
 func (c *vertexStreamContext) destroy() {
 	gl.DeleteBuffer(c.buffer)
 	c.buffer = gl.Buffer{}
+}
+
+// float32Bytes returns the byte representation of float32 values in little endian byte order.
+func float32Bytes(values ...float32) []byte {
+	b := make([]byte, 4*len(values))
+	for i, v := range values {
+		u := math.Float32bits(v)
+		b[4*i+0] = byte(u >> 0)
+		b[4*i+1] = byte(u >> 8)
+		b[4*i+2] = byte(u >> 16)
+		b[4*i+3] = byte(u >> 24)
+	}
+	return b
 }

--- a/drivers/gl/viewport.go
+++ b/drivers/gl/viewport.go
@@ -5,16 +5,15 @@
 package gl
 
 import (
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"unicode"
 
-	"github.com/go-gl/gl/v2.1/gl"
 	"github.com/go-gl/glfw/v3.1/glfw"
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl/platform"
 	"github.com/google/gxui/math"
+	"golang.org/x/mobile/gl"
 )
 
 const viewportDebugEnabled = false
@@ -82,9 +81,6 @@ func newViewport(driver *driver, width, height int, title string, fullscreen boo
 		panic(err)
 	}
 	wnd.MakeContextCurrent()
-	if err := gl.Init(); err != nil {
-		panic(fmt.Errorf("Failed to initialize gl: %v", err))
-	}
 
 	v.context = newContext()
 
@@ -109,7 +105,7 @@ func newViewport(driver *driver, width, height int, title string, fullscreen boo
 		v.Lock()
 		v.sizePixels = math.Size{W: w, H: h}
 		v.Unlock()
-		gl.Viewport(0, 0, int32(w), int32(h))
+		gl.Viewport(0, 0, w, h)
 		gl.ClearColor(kClearColorR, kClearColorG, kClearColorB, 1.0)
 		gl.Clear(gl.COLOR_BUFFER_BIT)
 	})
@@ -226,7 +222,7 @@ func newViewport(driver *driver, width, height int, title string, fullscreen boo
 	gl.BlendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA)
 	gl.Enable(gl.BLEND)
 	gl.Enable(gl.SCISSOR_TEST)
-	gl.Viewport(0, 0, int32(fw), int32(fh))
+	gl.Viewport(0, 0, fw, fh)
 	gl.Scissor(0, 0, int32(fw), int32(fh))
 	gl.ClearColor(kClearColorR, kClearColorG, kClearColorB, 1.0)
 	gl.Clear(gl.COLOR_BUFFER_BIT)

--- a/drivers/gl/viewport.go
+++ b/drivers/gl/viewport.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl/platform"
 	"github.com/google/gxui/math"
-	"golang.org/x/mobile/gl"
+	"github.com/goxjs/gl"
 )
 
 const viewportDebugEnabled = false

--- a/drivers/gl/viewport.go
+++ b/drivers/gl/viewport.go
@@ -81,6 +81,7 @@ func newViewport(driver *driver, width, height int, title string, fullscreen boo
 		panic(err)
 	}
 	wnd.MakeContextCurrent()
+	gl.ContextWatcher.OnMakeCurrent(nil)
 
 	v.context = newContext()
 
@@ -258,6 +259,7 @@ func (v *viewport) render() {
 	}
 
 	v.window.MakeContextCurrent()
+	gl.ContextWatcher.OnMakeCurrent(nil)
 
 	ctx := v.context
 	ctx.beginDraw(v.SizeDips(), v.SizePixels())
@@ -301,6 +303,7 @@ func (v *viewport) SetCanvas(cc gxui.Canvas) {
 	v.driver.asyncDriver(func() {
 		// Only use the canvas of the most recent SetCanvas call.
 		v.window.MakeContextCurrent()
+		gl.ContextWatcher.OnMakeCurrent(nil)
 		if atomic.LoadUint32(&v.redrawCount) == cnt {
 			if v.canvas != nil {
 				v.canvas.release()
@@ -435,6 +438,7 @@ func (v *viewport) Destroy() {
 	v.driver.asyncDriver(func() {
 		if !v.destroyed {
 			v.window.MakeContextCurrent()
+			gl.ContextWatcher.OnMakeCurrent(nil)
 			if v.canvas != nil {
 				v.canvas.Release()
 				v.canvas = nil

--- a/mouse_state.go
+++ b/mouse_state.go
@@ -9,4 +9,3 @@ type MouseState int
 func (s MouseState) IsDown(b MouseButton) bool {
 	return s&(1<<uint(b)) != 0
 }
-

--- a/utils.go
+++ b/utils.go
@@ -121,7 +121,7 @@ func WindowToChild(coord math.Point, to Control) math.Point {
 		child := p.Children().Find(c)
 		if child == nil {
 			Dump(p)
-			panic(fmt.Errorf("Control's parent (%p %T) did not contain control (%p %T).", p, p, c, c))
+			panic(fmt.Errorf("Control's parent (%p %T) did not contain control (%p %T).", &p, p, &c, c))
 		}
 		coord = coord.Sub(child.Offset)
 		if _, ok := p.(Window); ok {
@@ -141,7 +141,7 @@ func ChildToParent(coord math.Point, from Control, to Parent) math.Point {
 		child := p.Children().Find(c)
 		if child == nil {
 			Dump(p)
-			panic(fmt.Errorf("Control's parent (%p %T) did not contain control (%p %T).", p, p, c, c))
+			panic(fmt.Errorf("Control's parent (%p %T) did not contain control (%p %T).", &p, p, &c, c))
 		}
 		coord = coord.Add(child.Offset)
 		if p == to {
@@ -153,7 +153,7 @@ func ChildToParent(coord math.Point, from Control, to Parent) math.Point {
 		} else {
 			Dump(p)
 			panic(fmt.Errorf("ChildToParent (%p %T) -> (%p %T) reached non-control parent (%p %T).",
-				from, from, to, to, p, p))
+				&from, from, &to, to, &p, p))
 		}
 	}
 }


### PR DESCRIPTION
This PR is a continuation of #78. It's different in that it simply modifies the existing driver, rather than adding an second driver.

This PR modifies the gl driver to use `golang.org/x/mobile/gl` package. This package offers a slightly higher level interface, with desktop (OS X, Linux) and mobile (iOS, Android) backends. There is ongoing work to add support for Windows and web browsers.

Resolves #45.
Related to #49.

- The x/mobile/gl provides a universal GL interface which can run on desktop (OS X, Linux), mobile (iOS, Android), with current work to add support for Windows and web browsers.
- Change index buffer data type from []uint32 to []uint16, since it offers enough size, and WebGL implementations do not support []uint32 as readily.
- Remove stFloatMat2x3, stFloatMat2x4, stFloatMat3x2, stFloatMat3x4, stFloatMat4x2 and stFloatMat4x3 since x/mobile/gl does not currently have support for those operations they are unused.
- Remove gl.INVALID_INDEX since x/mobile/gl does not have it.
- Remove support for image.Gray format, since it's unused.
- HACK: Hardcode []uint16 support in newIndexBuffer, since x/mobile/gl has poor support for non-[]uint8 types at this time, only []uint16 is used. Need to improve this.
- HACK: Hardcode []float32 support in newVertexStream since it's the only type used, and x/mobile/gl currently has poor support for other types. Need to improve this.