### PR TITLE
Rework control layout logic.

### DIFF
--- a/container.go
+++ b/container.go
@@ -4,24 +4,82 @@
 
 package gxui
 
-import "github.com/google/gxui/math"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/google/gxui/math"
+)
+
+type Child struct {
+	Control Control
+	Offset  math.Point
+}
 
 type Parent interface {
-	Children() []Control
+	Children() Children
 }
 
 type Container interface {
 	Parent
 	Relayout()
 	Redraw()
-	ChildCount() int
-	ChildIndex(child Control) int
-	ChildAt(int) Control
-	AddChild(child Control)
-	AddChildAt(index int, child Control)
+	AddChild(child Control) *Child
+	AddChildAt(index int, child Control) *Child
 	RemoveChild(child Control)
 	RemoveChildAt(index int)
 	RemoveAll()
 	Padding() math.Spacing
 	SetPadding(math.Spacing)
+}
+
+// String returns a string describing the child type and bounds.
+func (c *Child) String() string {
+	return fmt.Sprintf("Type: %T, Bounds: %v", c.Control, c.Bounds())
+}
+
+// Bounds returns the Child bounds relative to the parent.
+func (c *Child) Bounds() math.Rect {
+	return c.Control.Size().Rect().Offset(c.Offset)
+}
+
+// Layout sets the Child size and offset relative to the parent.
+// Layout should only be called by the Child's parent.
+func (c *Child) Layout(rect math.Rect) {
+	c.Offset = rect.Min
+	c.Control.SetSize(rect.Size())
+}
+
+// Children is a list of Child pointers.
+type Children []*Child
+
+// String returns a string describing the child type and bounds.
+func (c Children) String() string {
+	s := make([]string, len(c))
+	for i, c := range c {
+		s[i] = fmt.Sprintf("%d: %s", i, c.String())
+	}
+	return strings.Join(s, "\n")
+}
+
+// IndexOf returns and returns the index of the child control, or -1 if the
+// child is not in this Children list.
+func (c Children) IndexOf(control Control) int {
+	for i, child := range c {
+		if child.Control == control {
+			return i
+		}
+	}
+	return -1
+}
+
+// Find returns and returns the Child pointer for the given Control, or nil
+// if the child is not in this Children list.
+func (c Children) Find(control Control) *Child {
+	for _, child := range c {
+		if child.Control == control {
+			return child
+		}
+	}
+	return nil
 }

--- a/control.go
+++ b/control.go
@@ -9,9 +9,9 @@ import (
 )
 
 type Control interface {
-	Layout(math.Rect)
+	Size() math.Size
+	SetSize(math.Size)
 	Draw() Canvas
-	Bounds() math.Rect
 	Parent() Container
 	SetParent(Container)
 	Attached() bool

--- a/debug.go
+++ b/debug.go
@@ -23,13 +23,15 @@ func dump(c interface{}, depth int) string {
 	s := ""
 	switch t := c.(type) {
 	case Control:
-		s += fmt.Sprintf("%s Bounds: %+v Margin: %+v \n", reflect.TypeOf(t).String(), t.Bounds(), t.Margin())
+		s += fmt.Sprintf("(%p) %T Size: %+v Margin: %+v \n", t, t, t.Size(), t.Margin())
+	default:
+		s += fmt.Sprintf("%T\n", t)
 	}
 	switch t := c.(type) {
 	case Container:
 		for i, c := range t.Children() {
 			s += fmt.Sprintf("%s--- Child %d: ", indent(depth), i)
-			s += dump(c, depth+1)
+			s += dump(c.Control, depth+1)
 		}
 	}
 	return s
@@ -46,13 +48,13 @@ func FunctionName(i interface{}) string {
 func BreadcrumbsAt(p Container, pnt math.Point) string {
 	s := reflect.TypeOf(p).String()
 	for _, c := range p.Children() {
-		b := c.Bounds()
+		b := c.Control.Size().Rect().Offset(c.Offset)
 		if b.Contains(pnt) {
-			switch t := c.(type) {
+			switch t := c.Control.(type) {
 			case Container:
-				return s + " > " + BreadcrumbsAt(t, pnt.Sub(b.Min))
+				return s + " > " + BreadcrumbsAt(t, pnt.Sub(c.Offset))
 			default:
-				return s + " > " + reflect.TypeOf(c).String()
+				return s + " > " + reflect.TypeOf(c.Control).String()
 			}
 		}
 	}

--- a/drivers/gl/viewport.go
+++ b/drivers/gl/viewport.go
@@ -343,6 +343,14 @@ func (v *viewport) SizeDips() math.Size {
 	return v.sizeDips
 }
 
+func (v *viewport) SetSizeDips(size math.Size) {
+	v.driver.syncDriver(func() {
+		v.sizeDips = size
+		v.sizeDipsUnscaled = size.ScaleS(v.scaling)
+		v.window.SetSize(v.sizeDipsUnscaled.W, v.sizeDipsUnscaled.H)
+	})
+}
+
 func (v *viewport) SizePixels() math.Size {
 	v.Lock()
 	defer v.Unlock()

--- a/focus_controller.go
+++ b/focus_controller.go
@@ -97,18 +97,17 @@ func (c *FocusController) NextChildFocusable(p Container, after Control, forward
 		}
 
 		if !examineNext {
-			if f == after {
+			if f.Control == after {
 				examineNext = true
 			}
 			continue
 		}
 
-		if focusable := c.Focusable(f); focusable != nil {
+		if focusable := c.Focusable(f.Control); focusable != nil {
 			return focusable
 		}
 
-		container, _ := f.(Container)
-		if container != nil {
+		if container, ok := f.Control.(Container); ok {
 			focusable := c.NextChildFocusable(container, nil, forwards)
 			if focusable != nil {
 				return focusable

--- a/mixins/base/control.go
+++ b/mixins/base/control.go
@@ -44,5 +44,5 @@ func (c *Control) DesiredSize(min, max math.Size) math.Size {
 }
 
 func (c *Control) ContainsPoint(p math.Point) bool {
-	return c.IsVisible() && c.Bounds().Size().Rect().Contains(p)
+	return c.IsVisible() && c.Size().Rect().Contains(p)
 }

--- a/mixins/bubble_overlay.go
+++ b/mixins/bubble_overlay.go
@@ -17,7 +17,6 @@ type BubbleOverlayOuter interface {
 type BubbleOverlay struct {
 	base.Container
 	outer       BubbleOverlayOuter
-	control     gxui.Control
 	targetPoint math.Point
 	arrowLength int
 	arrowWidth  int
@@ -36,14 +35,13 @@ func (o *BubbleOverlay) Init(outer BubbleOverlayOuter, theme gxui.Theme) {
 }
 
 func (o *BubbleOverlay) LayoutChildren() {
-	control := o.control
-	if control != nil {
-		bounds := o.outer.Bounds().Contract(o.outer.Padding())
+	for _, child := range o.outer.Children() {
+		bounds := o.outer.Size().Rect().Contract(o.outer.Padding())
 		arrowPadding := math.CreateSpacing(o.arrowLength)
-		cm := control.Margin()
-		cs := control.DesiredSize(math.ZeroSize, bounds.Size().Contract(cm).Max(math.ZeroSize))
+		cm := child.Control.Margin()
+		cs := child.Control.DesiredSize(math.ZeroSize, bounds.Size().Contract(cm).Max(math.ZeroSize))
 		cr := cs.Expand(arrowPadding).EdgeAlignedFit(bounds, o.targetPoint).Contract(arrowPadding)
-		control.Layout(cr)
+		child.Layout(cr)
 	}
 }
 
@@ -54,12 +52,10 @@ func (o *BubbleOverlay) DesiredSize(min, max math.Size) math.Size {
 func (o *BubbleOverlay) Show(control gxui.Control, target math.Point) {
 	o.Hide()
 	o.outer.AddChild(control)
-	o.control = control
 	o.targetPoint = target
 }
 
 func (o *BubbleOverlay) Hide() {
-	o.control = nil
 	o.outer.RemoveAll()
 }
 
@@ -86,92 +82,92 @@ func (o *BubbleOverlay) SetPen(pen gxui.Pen) {
 }
 
 func (o *BubbleOverlay) Paint(c gxui.Canvas) {
-	control := o.control
-	if control == nil || !o.IsVisible() {
+	if !o.IsVisible() {
 		return
 	}
+	for _, child := range o.outer.Children() {
+		b := child.Bounds().Expand(o.outer.Padding())
+		t := o.targetPoint
+		a := o.arrowWidth / 2
+		var p gxui.Polygon
 
-	b := control.Bounds().Expand(o.outer.Padding())
-	t := o.targetPoint
-	a := o.arrowWidth / 2
-	var p gxui.Polygon
-
-	switch {
-	case t.X < b.Min.X:
-		/*
-		    A-----------------B
-		    G                 |
-		 F                    |
-		    E                 |
-		    D-----------------C
-		*/
-		p = gxui.Polygon{
-			/*A*/ {Position: b.TL(), RoundedRadius: 5},
-			/*B*/ {Position: b.TR(), RoundedRadius: 5},
-			/*C*/ {Position: b.BR(), RoundedRadius: 5},
-			/*D*/ {Position: b.BL(), RoundedRadius: 5},
-			/*E*/ {Position: math.Point{X: b.Min.X, Y: math.Clamp(t.Y+a, b.Min.Y+a, b.Max.Y)}, RoundedRadius: 0},
-			/*F*/ {Position: t, RoundedRadius: 0},
-			/*G*/ {Position: math.Point{X: b.Min.X, Y: math.Clamp(t.Y-a, b.Min.Y, b.Max.Y-a)}, RoundedRadius: 0},
+		switch {
+		case t.X < b.Min.X:
+			/*
+			    A-----------------B
+			    G                 |
+			 F                    |
+			    E                 |
+			    D-----------------C
+			*/
+			p = gxui.Polygon{
+				/*A*/ {Position: b.TL(), RoundedRadius: 5},
+				/*B*/ {Position: b.TR(), RoundedRadius: 5},
+				/*C*/ {Position: b.BR(), RoundedRadius: 5},
+				/*D*/ {Position: b.BL(), RoundedRadius: 5},
+				/*E*/ {Position: math.Point{X: b.Min.X, Y: math.Clamp(t.Y+a, b.Min.Y+a, b.Max.Y)}, RoundedRadius: 0},
+				/*F*/ {Position: t, RoundedRadius: 0},
+				/*G*/ {Position: math.Point{X: b.Min.X, Y: math.Clamp(t.Y-a, b.Min.Y, b.Max.Y-a)}, RoundedRadius: 0},
+			}
+			// fmt.Printf("A: %+v\n", p)
+		case t.X > b.Max.X:
+			/*
+			   A-----------------B
+			   |                 C
+			   |                    D
+			   |                 E
+			   G-----------------F
+			*/
+			p = gxui.Polygon{
+				/*A*/ {Position: b.TL(), RoundedRadius: 5},
+				/*B*/ {Position: b.TR(), RoundedRadius: 5},
+				/*C*/ {Position: math.Point{X: b.Max.X, Y: math.Clamp(t.Y-a, b.Min.Y, b.Max.Y-a)}, RoundedRadius: 0},
+				/*D*/ {Position: t, RoundedRadius: 0},
+				/*E*/ {Position: math.Point{X: b.Max.X, Y: math.Clamp(t.Y+a, b.Min.Y+a, b.Max.Y)}, RoundedRadius: 0},
+				/*F*/ {Position: b.BR(), RoundedRadius: 5},
+				/*G*/ {Position: b.BL(), RoundedRadius: 5},
+			}
+			// fmt.Printf("B: %+v\n", p)
+		case t.Y < b.Min.Y:
+			/*
+			                 C
+			                / \
+			   A-----------B   D-E
+			   |                 |
+			   |                 |
+			   G-----------------F
+			*/
+			p = gxui.Polygon{
+				/*A*/ {Position: b.TL(), RoundedRadius: 5},
+				/*B*/ {Position: math.Point{X: math.Clamp(t.X-a, b.Min.X, b.Max.X-a), Y: b.Min.Y}, RoundedRadius: 0},
+				/*C*/ {Position: t, RoundedRadius: 0},
+				/*D*/ {Position: math.Point{X: math.Clamp(t.X+a, b.Min.X+a, b.Max.X), Y: b.Min.Y}, RoundedRadius: 0},
+				/*E*/ {Position: b.TR(), RoundedRadius: 5},
+				/*F*/ {Position: b.BR(), RoundedRadius: 5},
+				/*G*/ {Position: b.BL(), RoundedRadius: 5},
+			}
+			// fmt.Printf("C: %+v\n", p)
+		default:
+			/*
+			   A-----------------B
+			   |                 |
+			   |                 |
+			   G-----------F   D-C
+			                \ /
+			                 E
+			*/
+			p = gxui.Polygon{
+				/*A*/ {Position: b.TL(), RoundedRadius: 5},
+				/*B*/ {Position: b.TR(), RoundedRadius: 5},
+				/*C*/ {Position: b.BR(), RoundedRadius: 5},
+				/*D*/ {Position: math.Point{X: math.Clamp(t.X+a, b.Min.X+a, b.Max.X), Y: b.Max.Y}, RoundedRadius: 0},
+				/*E*/ {Position: t, RoundedRadius: 0},
+				/*F*/ {Position: math.Point{X: math.Clamp(t.X-a, b.Min.X, b.Max.X-a), Y: b.Max.Y}, RoundedRadius: 0},
+				/*G*/ {Position: b.BL(), RoundedRadius: 5},
+			}
+			// fmt.Printf("D: %+v\n", p)
 		}
-		// fmt.Printf("A: %+v\n", p)
-	case t.X > b.Max.X:
-		/*
-		   A-----------------B
-		   |                 C
-		   |                    D
-		   |                 E
-		   G-----------------F
-		*/
-		p = gxui.Polygon{
-			/*A*/ {Position: b.TL(), RoundedRadius: 5},
-			/*B*/ {Position: b.TR(), RoundedRadius: 5},
-			/*C*/ {Position: math.Point{X: b.Max.X, Y: math.Clamp(t.Y-a, b.Min.Y, b.Max.Y-a)}, RoundedRadius: 0},
-			/*D*/ {Position: t, RoundedRadius: 0},
-			/*E*/ {Position: math.Point{X: b.Max.X, Y: math.Clamp(t.Y+a, b.Min.Y+a, b.Max.Y)}, RoundedRadius: 0},
-			/*F*/ {Position: b.BR(), RoundedRadius: 5},
-			/*G*/ {Position: b.BL(), RoundedRadius: 5},
-		}
-		// fmt.Printf("B: %+v\n", p)
-	case t.Y < b.Min.Y:
-		/*
-		                 C
-		                / \
-		   A-----------B   D-E
-		   |                 |
-		   |                 |
-		   G-----------------F
-		*/
-		p = gxui.Polygon{
-			/*A*/ {Position: b.TL(), RoundedRadius: 5},
-			/*B*/ {Position: math.Point{X: math.Clamp(t.X-a, b.Min.X, b.Max.X-a), Y: b.Min.Y}, RoundedRadius: 0},
-			/*C*/ {Position: t, RoundedRadius: 0},
-			/*D*/ {Position: math.Point{X: math.Clamp(t.X+a, b.Min.X+a, b.Max.X), Y: b.Min.Y}, RoundedRadius: 0},
-			/*E*/ {Position: b.TR(), RoundedRadius: 5},
-			/*F*/ {Position: b.BR(), RoundedRadius: 5},
-			/*G*/ {Position: b.BL(), RoundedRadius: 5},
-		}
-		// fmt.Printf("C: %+v\n", p)
-	default:
-		/*
-		   A-----------------B
-		   |                 |
-		   |                 |
-		   G-----------F   D-C
-		                \ /
-		                 E
-		*/
-		p = gxui.Polygon{
-			/*A*/ {Position: b.TL(), RoundedRadius: 5},
-			/*B*/ {Position: b.TR(), RoundedRadius: 5},
-			/*C*/ {Position: b.BR(), RoundedRadius: 5},
-			/*D*/ {Position: math.Point{X: math.Clamp(t.X+a, b.Min.X+a, b.Max.X), Y: b.Max.Y}, RoundedRadius: 0},
-			/*E*/ {Position: t, RoundedRadius: 0},
-			/*F*/ {Position: math.Point{X: math.Clamp(t.X-a, b.Min.X, b.Max.X-a), Y: b.Max.Y}, RoundedRadius: 0},
-			/*G*/ {Position: b.BL(), RoundedRadius: 5},
-		}
-		// fmt.Printf("D: %+v\n", p)
+		c.DrawPolygon(p, o.pen, o.brush)
 	}
-	c.DrawPolygon(p, o.pen, o.brush)
 	o.PaintChildren.Paint(c)
 }

--- a/mixins/code_editor_line.go
+++ b/mixins/code_editor_line.go
@@ -101,7 +101,7 @@ func (t *CodeEditorLine) PaintBorders(c gxui.Canvas, info CodeEditorLinePaintInf
 // DefaultTextBoxLine overrides
 func (t *CodeEditorLine) Paint(c gxui.Canvas) {
 	font := t.ce.font
-	rect := t.Bounds().Size().Rect().OffsetX(t.caretWidth)
+	rect := t.Size().Rect().OffsetX(t.caretWidth)
 	controller := t.ce.controller
 	runes := controller.LineRunes(t.lineIndex)
 	start := controller.LineStart(t.lineIndex)
@@ -110,7 +110,7 @@ func (t *CodeEditorLine) Paint(c gxui.Canvas) {
 	if start != end {
 		lineSpan := interval.CreateIntData(start, end, nil)
 
-		lineHeight := t.Bounds().Size().H
+		lineHeight := t.Size().H
 		glyphWidth := font.GlyphMaxSize().W
 		offsets := font.Layout(&gxui.TextBlock{
 			Runes:     runes,

--- a/mixins/default_textbox_line.go
+++ b/mixins/default_textbox_line.go
@@ -79,7 +79,7 @@ func (t *DefaultTextBoxLine) PaintText(c gxui.Canvas) {
 	f := t.textbox.font
 	offsets := f.Layout(&gxui.TextBlock{
 		Runes:     runes,
-		AlignRect: t.Bounds().Size().Rect().OffsetX(t.caretWidth),
+		AlignRect: t.Size().Rect().OffsetX(t.caretWidth),
 		H:         gxui.AlignLeft,
 		V:         gxui.AlignBottom,
 	})
@@ -95,7 +95,7 @@ func (t *DefaultTextBoxLine) PaintCarets(c gxui.Canvas) {
 			s := controller.LineStart(l)
 			m := t.outer.MeasureRunes(s, e)
 			top := math.Point{X: t.caretWidth + m.W, Y: 0}
-			bottom := top.Add(math.Point{X: 0, Y: t.Bounds().H()})
+			bottom := top.Add(math.Point{X: 0, Y: t.Size().H})
 			t.outer.PaintCaret(c, top, bottom)
 		}
 	}

--- a/mixins/drop_down_list.go
+++ b/mixins/drop_down_list.go
@@ -27,7 +27,7 @@ type DropDownList struct {
 	listShowing bool
 	itemSize    math.Size
 	overlay     gxui.BubbleOverlay
-	selected    gxui.Control
+	selected    *gxui.Child
 	onShowList  gxui.Event
 	onHideList  gxui.Event
 }
@@ -44,8 +44,7 @@ func (l *DropDownList) Init(outer DropDownListOuter, theme gxui.Theme) {
 		l.outer.RemoveAll()
 		adapter := l.list.Adapter()
 		if item != nil && adapter != nil {
-			l.selected = adapter.Create(l.theme, adapter.ItemIndex(item))
-			l.AddChild(l.selected)
+			l.selected = l.AddChild(adapter.Create(l.theme, adapter.ItemIndex(item)))
 		} else {
 			l.selected = nil
 		}
@@ -76,7 +75,7 @@ func (l *DropDownList) LayoutChildren() {
 	}
 
 	if l.selected != nil {
-		s := l.outer.Bounds().Size().Contract(l.Padding()).Max(math.ZeroSize)
+		s := l.outer.Size().Contract(l.Padding()).Max(math.ZeroSize)
 		o := l.Padding().LT()
 		l.selected.Layout(s.Rect().Offset(o))
 	}
@@ -84,7 +83,7 @@ func (l *DropDownList) LayoutChildren() {
 
 func (l *DropDownList) DesiredSize(min, max math.Size) math.Size {
 	if l.selected != nil {
-		return l.selected.DesiredSize(min, max).Expand(l.outer.Padding()).Clamp(min, max)
+		return l.selected.Control.DesiredSize(min, max).Expand(l.outer.Padding()).Clamp(min, max)
 	} else {
 		return l.itemSize.Expand(l.outer.Padding()).Clamp(min, max)
 	}
@@ -106,9 +105,9 @@ func (l *DropDownList) ShowList() bool {
 		return false
 	}
 	l.listShowing = true
-	s := l.Bounds().Size()
+	s := l.Size()
 	at := math.Point{X: s.W / 2, Y: s.H}
-	l.overlay.Show(l.list, gxui.TransformCoordinate(at, l, l.overlay))
+	l.overlay.Show(l.list, gxui.TransformCoordinate(at, l.outer, l.overlay))
 	gxui.SetFocus(l.list)
 	if l.onShowList != nil {
 		l.onShowList.Fire()
@@ -211,7 +210,7 @@ func (l *DropDownList) KeyPress(ev gxui.KeyboardEvent) (consume bool) {
 
 // parts.Container overrides
 func (l *DropDownList) Paint(c gxui.Canvas) {
-	r := l.outer.Bounds().Size().Rect()
+	r := l.outer.Size().Rect()
 	l.PaintBackground(c, r)
 	l.Container.Paint(c)
 	l.PaintBorder(c, r)

--- a/mixins/image.go
+++ b/mixins/image.go
@@ -28,7 +28,7 @@ type Image struct {
 }
 
 func (i *Image) calculateDrawRect() math.Rect {
-	r := i.outer.Bounds().Size().Rect()
+	r := i.outer.Size().Rect()
 	texW, texH := i.texture.Size().WH()
 	aspectSrc := float32(texH) / float32(texW)
 	aspectDst := float32(r.H()) / float32(r.W())
@@ -145,7 +145,7 @@ func (i *Image) DesiredSize(min, max math.Size) math.Size {
 }
 
 func (i *Image) Paint(c gxui.Canvas) {
-	r := i.outer.Bounds().Size().Rect()
+	r := i.outer.Size().Rect()
 	i.PaintBackground(c, r)
 	switch {
 	case i.texture != nil:

--- a/mixins/label.go
+++ b/mixins/label.go
@@ -119,7 +119,7 @@ func (l *Label) VerticalAlignment() gxui.VerticalAlignment {
 
 // parts.DrawPaint overrides
 func (l *Label) Paint(c gxui.Canvas) {
-	r := l.outer.Bounds().Size().Rect()
+	r := l.outer.Size().Rect()
 	t := l.text
 	if !l.multiline {
 		t = strings.Replace(t, "\n", " ", -1)

--- a/mixins/linear_layout.go
+++ b/mixins/linear_layout.go
@@ -33,7 +33,7 @@ func (l *LinearLayout) Init(outer LinearLayoutOuter, theme gxui.Theme) {
 }
 
 func (l *LinearLayout) Paint(c gxui.Canvas) {
-	r := l.Bounds().Size().Rect()
+	r := l.Size().Rect()
 	l.BackgroundBorderPainter.PaintBackground(c, r)
 	l.PaintChildren.Paint(c)
 	l.BackgroundBorderPainter.PaintBorder(c, r)

--- a/mixins/outer/paint_childer.go
+++ b/mixins/outer/paint_childer.go
@@ -9,5 +9,5 @@ import (
 )
 
 type PaintChilder interface {
-	PaintChild(c gxui.Canvas, child gxui.Control, idx int)
+	PaintChild(c gxui.Canvas, child *gxui.Child, idx int)
 }

--- a/mixins/outer/sized.go
+++ b/mixins/outer/sized.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/gxui/math"
 )
 
-type Bounds interface {
-	Bounds() math.Rect
+type Sized interface {
+	Size() math.Size
+	SetSize(math.Size)
 }

--- a/mixins/panel_holder.go
+++ b/mixins/panel_holder.go
@@ -58,9 +58,11 @@ func insertIndex(holder gxui.PanelHolder, at math.Point) int {
 	}
 	for i := 0; i < holder.PanelCount(); i++ {
 		tab := holder.Tab(i)
-		bounds := tab.Bounds()
-		score(bounds.ML(), i)
-		score(bounds.MR(), i+1)
+		size := tab.Size()
+		ml := math.Point{Y: size.H / 2}
+		mr := math.Point{Y: size.H / 2, X: size.W}
+		score(gxui.TransformCoordinate(ml, tab, holder), i)
+		score(gxui.TransformCoordinate(mr, tab, holder), i+1)
 	}
 	return bestIndex
 }
@@ -106,16 +108,19 @@ func (p *PanelHolder) Init(outer PanelHolderOuter, theme gxui.Theme) {
 }
 
 func (p *PanelHolder) LayoutChildren() {
-	s := p.Bounds().Size()
+	s := p.Size()
 
 	tabHeight := p.tabLayout.DesiredSize(math.ZeroSize, s).H
 	panelRect := math.CreateRect(0, tabHeight, s.W, s.H).Contract(p.Padding())
 
-	for _, c := range p.Children() {
-		if c == p.tabLayout {
-			c.Layout(math.CreateRect(0, 0, s.W, tabHeight))
+	for _, child := range p.Children() {
+		if child.Control == p.tabLayout {
+			child.Control.SetSize(math.Size{W: s.W, H: tabHeight})
+			child.Offset = math.ZeroPoint
 		} else {
-			c.Layout(panelRect.Contract(c.Margin()))
+			rect := panelRect.Contract(child.Control.Margin())
+			child.Control.SetSize(rect.Size())
+			child.Offset = rect.Min
 		}
 	}
 }

--- a/mixins/parts/draw_paint.go
+++ b/mixins/parts/draw_paint.go
@@ -16,9 +16,9 @@ const debugVerifyDetachOnGC = false
 
 type DrawPaintOuter interface {
 	outer.Attachable
-	outer.Bounds
 	outer.Painter
 	outer.Parenter
+	outer.Sized
 }
 
 type DrawPaint struct {
@@ -64,7 +64,7 @@ func (d *DrawPaint) Draw() gxui.Canvas {
 		panic(fmt.Errorf("Attempting to draw a non-attached control %T", d.outer))
 	}
 
-	s := d.outer.Bounds().Size()
+	s := d.outer.Size()
 	if s.Area() == 0 {
 		return nil // No area to draw in
 	}

--- a/mixins/parts/layoutable.go
+++ b/mixins/parts/layoutable.go
@@ -19,7 +19,7 @@ type LayoutableOuter interface {
 type Layoutable struct {
 	outer             LayoutableOuter
 	margin            math.Spacing
-	rect              math.Rect
+	size              math.Size
 	relayoutRequested bool
 	inLayoutChildren  bool // True when calling LayoutChildren
 }
@@ -39,21 +39,21 @@ func (l *Layoutable) Margin() math.Spacing {
 	return l.margin
 }
 
-func (l *Layoutable) Bounds() math.Rect {
-	return l.rect
+func (l *Layoutable) Size() math.Size {
+	return l.size
 }
 
-func (l *Layoutable) Layout(rect math.Rect) {
-	if rect.W() < 0 {
-		panic(fmt.Errorf("Layout() called with a negative width. Rect: %v", rect))
+func (l *Layoutable) SetSize(size math.Size) {
+	if size.W < 0 {
+		panic(fmt.Errorf("SetSize() called with a negative width. Size: %v", size))
 	}
-	if rect.H() < 0 {
-		panic(fmt.Errorf("Layout() called with a negative height. Rect: %v", rect))
+	if size.H < 0 {
+		panic(fmt.Errorf("SetSize() called with a negative height. Size: %v", size))
 	}
 
-	boundsChanged := l.rect != rect
-	l.rect = rect
-	if l.relayoutRequested || boundsChanged {
+	sizeChanged := l.size != size
+	l.size = size
+	if l.relayoutRequested || sizeChanged {
 		l.relayoutRequested = false
 		l.inLayoutChildren = true
 		callLayoutChildrenIfSupported(l.outer)

--- a/mixins/parts/paint_children.go
+++ b/mixins/parts/paint_children.go
@@ -11,8 +11,8 @@ import (
 
 type PaintChildrenOuter interface {
 	gxui.Container
-	outer.Bounds
 	outer.PaintChilder
+	outer.Sized
 }
 
 type PaintChildren struct {
@@ -25,18 +25,17 @@ func (p *PaintChildren) Init(outer PaintChildrenOuter) {
 
 func (p *PaintChildren) Paint(c gxui.Canvas) {
 	for i, v := range p.outer.Children() {
-		if v.IsVisible() {
+		if v.Control.IsVisible() {
 			c.Push()
-			c.AddClip(v.Bounds())
+			c.AddClip(v.Control.Size().Rect().Offset(v.Offset))
 			p.outer.PaintChild(c, v, i)
 			c.Pop()
 		}
 	}
 }
 
-func (p *PaintChildren) PaintChild(c gxui.Canvas, child gxui.Control, idx int) {
-	childCanvas := child.Draw()
-	if childCanvas != nil {
-		c.DrawCanvas(childCanvas, child.Bounds().Min)
+func (p *PaintChildren) PaintChild(c gxui.Canvas, child *gxui.Child, idx int) {
+	if canvas := child.Control.Draw(); canvas != nil {
+		c.DrawCanvas(canvas, child.Offset)
 	}
 }

--- a/mixins/progress_bar.go
+++ b/mixins/progress_bar.go
@@ -38,7 +38,7 @@ func (b *ProgressBar) Init(outer ProgressBarOuter, theme gxui.Theme) {
 
 func (b *ProgressBar) Paint(c gxui.Canvas) {
 	frac := math.Saturate(float32(b.progress) / float32(b.target))
-	r := b.outer.Bounds().Size().Rect()
+	r := b.outer.Size().Rect()
 	b.PaintBackground(c, r)
 	b.outer.PaintProgress(c, r, frac)
 	b.PaintBorder(c, r)

--- a/mixins/scroll_bar.go
+++ b/mixins/scroll_bar.go
@@ -19,7 +19,7 @@ type ScrollBar struct {
 	outer ScrollBarOuter
 
 	orientation         gxui.Orientation
-	desiredWidth        int
+	thickness           int
 	minBarLength        int
 	scrollPositionFrom  int
 	scrollPositionTo    int
@@ -33,7 +33,7 @@ type ScrollBar struct {
 
 func (s *ScrollBar) positionAt(p math.Point) int {
 	o := s.orientation
-	frac := float32(o.Major(p.XY())) / float32(o.Major(s.Bounds().Size().WH()))
+	frac := float32(o.Major(p.XY())) / float32(o.Major(s.Size().WH()))
 	max := s.ScrollLimit()
 	return int(float32(max) * frac)
 }
@@ -47,7 +47,7 @@ func (s *ScrollBar) rangeAt(p math.Point) (from, to int) {
 
 func (s *ScrollBar) updateBarRect() {
 	sf, st := s.ScrollFraction()
-	size := s.Bounds().Size()
+	size := s.Size()
 	b := size.Rect()
 	halfMinLen := s.minBarLength / 2
 	if s.orientation.Horizontal() {
@@ -74,7 +74,7 @@ func (s *ScrollBar) Init(outer ScrollBarOuter, theme gxui.Theme) {
 	s.Control.Init(outer, theme)
 
 	s.outer = outer
-	s.desiredWidth = 10
+	s.thickness = 10
 	s.minBarLength = 10
 	s.scrollPositionFrom = 0
 	s.scrollPositionTo = 100
@@ -97,14 +97,14 @@ func (s *ScrollBar) ScrollFraction() (from, to float32) {
 
 func (s *ScrollBar) DesiredSize(min, max math.Size) math.Size {
 	if s.orientation.Horizontal() {
-		return math.Size{W: max.W, H: s.desiredWidth}.Clamp(min, max)
+		return math.Size{W: max.W, H: s.thickness}.Clamp(min, max)
 	} else {
-		return math.Size{W: s.desiredWidth, H: max.H}.Clamp(min, max)
+		return math.Size{W: s.thickness, H: max.H}.Clamp(min, max)
 	}
 }
 
 func (s *ScrollBar) Paint(c gxui.Canvas) {
-	c.DrawRoundedRect(s.outer.Bounds().Size().Rect(), 3, 3, 3, 3, s.railPen, s.railBrush)
+	c.DrawRoundedRect(s.outer.Size().Rect(), 3, 3, 3, 3, s.railPen, s.railBrush)
 	c.DrawRoundedRect(s.barRect, 3, 3, 3, 3, s.barPen, s.barBrush)
 }
 
@@ -230,7 +230,7 @@ func (s *ScrollBar) MouseDown(ev gxui.MouseEvent) {
 		initialOffset := ev.Point.Sub(s.barRect.Min)
 		var mms, mus gxui.EventSubscription
 		mms = ev.Window.OnMouseMove(func(we gxui.MouseEvent) {
-			p := gxui.WindowToChild(we.WindowPoint, s)
+			p := gxui.WindowToChild(we.WindowPoint, s.outer)
 			s.SetScrollPosition(s.rangeAt(p.Sub(initialOffset)))
 		})
 		mus = ev.Window.OnMouseUp(func(we gxui.MouseEvent) {

--- a/mixins/splitter_bar.go
+++ b/mixins/splitter_bar.go
@@ -64,7 +64,7 @@ func (b *SplitterBar) OnDragEnd(f func(gxui.MouseEvent)) gxui.EventSubscription 
 
 // parts.DrawPaint overrides
 func (b *SplitterBar) Paint(c gxui.Canvas) {
-	r := b.outer.Bounds().Size().Rect()
+	r := b.outer.Size().Rect()
 	c.DrawRect(r, gxui.CreateBrush(b.backgroundColor))
 	if b.foregroundColor != b.backgroundColor {
 		c.DrawRect(r.ContractI(1), gxui.CreateBrush(b.foregroundColor))

--- a/mixins/textbox.go
+++ b/mixins/textbox.go
@@ -90,11 +90,11 @@ func (t *TextBox) Init(outer TextBoxOuter, driver gxui.Driver, theme gxui.Theme,
 }
 
 func (t *TextBox) textRect() math.Rect {
-	return t.outer.Bounds().Size().Rect().Contract(t.Padding())
+	return t.outer.Size().Rect().Contract(t.Padding())
 }
 
 func (t *TextBox) pageLines() int {
-	return (t.outer.Bounds().H() - t.outer.Padding().H()) / t.MajorAxisItemSize()
+	return (t.outer.Size().H - t.outer.Padding().H()) / t.MajorAxisItemSize()
 }
 
 func (t *TextBox) OnRedrawLines(f func()) gxui.EventSubscription {

--- a/mixins/tree.go
+++ b/mixins/tree.go
@@ -104,7 +104,7 @@ func (t *Tree) PaintUnexpandedSelection(c gxui.Canvas, r math.Rect) {
 }
 
 // List override
-func (t *Tree) PaintChild(c gxui.Canvas, child gxui.Control, idx int) {
+func (t *Tree) PaintChild(c gxui.Canvas, child *gxui.Child, idx int) {
 	t.List.PaintChild(c, child, idx)
 	if t.selectedItem != nil {
 		item := t.listAdapter.DeepestVisibleAncestor(t.selectedItem)
@@ -112,8 +112,8 @@ func (t *Tree) PaintChild(c gxui.Canvas, child gxui.Control, idx int) {
 			// The selected item is hidden by an unexpanded node.
 			// Highlight the deepest visible node instead.
 			if details, found := t.details[item]; found {
-				if child == details.control {
-					b := child.Bounds().Expand(child.Margin())
+				if child == details.child {
+					b := child.Bounds().Expand(child.Control.Margin())
 					t.outer.PaintUnexpandedSelection(c, b)
 				}
 			}

--- a/mixins/window.go
+++ b/mixins/window.go
@@ -14,12 +14,12 @@ import (
 type WindowOuter interface {
 	gxui.Window
 	outer.Attachable
-	outer.Bounds
 	outer.IsVisibler
 	outer.LayoutChildren
 	outer.PaintChilder
 	outer.Painter
 	outer.Parenter
+	outer.Sized
 }
 
 type Window struct {
@@ -150,16 +150,19 @@ func (w *Window) Paint(c gxui.Canvas) {
 }
 
 func (w *Window) LayoutChildren() {
-	s := w.Bounds().Size().Contract(w.Padding()).Max(math.ZeroSize)
+	s := w.Size().Contract(w.Padding()).Max(math.ZeroSize)
 	o := w.Padding().LT()
 	for _, c := range w.outer.Children() {
-		c.Layout(c.DesiredSize(math.ZeroSize, s).Rect().Offset(o))
+		c.Layout(c.Control.DesiredSize(math.ZeroSize, s).Rect().Offset(o))
 	}
 }
 
-func (w *Window) Bounds() math.Rect {
-	s := w.viewport.SizeDips()
-	return math.CreateRect(0, 0, s.W, s.H)
+func (w *Window) Size() math.Size {
+	return w.viewport.SizeDips()
+}
+
+func (w *Window) SetSize(size math.Size) {
+	w.viewport.SetSizeDips(size)
 }
 
 func (w *Window) Parent() gxui.Container {

--- a/themes/dark/button.go
+++ b/themes/dark/button.go
@@ -53,7 +53,7 @@ func (b *Button) Paint(c gxui.Canvas) {
 		l.SetColor(fontColor)
 	}
 
-	r := b.Bounds().Size().Rect()
+	r := b.Size().Rect()
 
 	c.DrawRoundedRect(r, 2, 2, 2, 2, gxui.TransparentPen, brush)
 

--- a/themes/dark/code_editor.go
+++ b/themes/dark/code_editor.go
@@ -32,7 +32,7 @@ func (t *CodeEditor) Paint(c gxui.Canvas) {
 	t.CodeEditor.Paint(c)
 
 	if t.HasFocus() {
-		r := t.Bounds().Size().Rect()
+		r := t.Size().Rect()
 		c.DrawRoundedRect(r, 3, 3, 3, 3, t.theme.FocusedStyle.Pen, t.theme.FocusedStyle.Brush)
 	}
 }

--- a/themes/dark/drop_down_list.go
+++ b/themes/dark/drop_down_list.go
@@ -39,7 +39,7 @@ func CreateDropDownList(theme *Theme) gxui.DropDownList {
 func (l *DropDownList) Paint(c gxui.Canvas) {
 	l.DropDownList.Paint(c)
 	if l.HasFocus() || l.ListShowing() {
-		r := l.Bounds().Size().Rect().ContractI(1)
+		r := l.Size().Rect().ContractI(1)
 		c.DrawRoundedRect(r, 3.0, 3.0, 3.0, 3.0, l.theme.FocusedStyle.Pen, l.theme.FocusedStyle.Brush)
 	}
 }

--- a/themes/dark/list.go
+++ b/themes/dark/list.go
@@ -30,7 +30,7 @@ func CreateList(theme *Theme) gxui.List {
 func (l *List) Paint(c gxui.Canvas) {
 	l.List.Paint(c)
 	if l.HasFocus() {
-		r := l.Bounds().Size().Rect().ContractI(1)
+		r := l.Size().Rect().ContractI(1)
 		c.DrawRoundedRect(r, 3.0, 3.0, 3.0, 3.0, l.theme.FocusedStyle.Pen, l.theme.FocusedStyle.Brush)
 	}
 }

--- a/themes/dark/panel_holder.go
+++ b/themes/dark/panel_holder.go
@@ -30,7 +30,8 @@ func (p *PanelHolder) CreatePanelTab() mixins.PanelTab {
 func (p *PanelHolder) Paint(c gxui.Canvas) {
 	panel := p.SelectedPanel()
 	if panel != nil {
-		c.DrawRoundedRect(panel.Bounds(), 0.0, 0.0, 3.0, 3.0, p.theme.PanelBackgroundStyle.Pen, p.theme.PanelBackgroundStyle.Brush)
+		bounds := p.Children().Find(panel).Bounds()
+		c.DrawRoundedRect(bounds, 0.0, 0.0, 3.0, 3.0, p.theme.PanelBackgroundStyle.Pen, p.theme.PanelBackgroundStyle.Brush)
 	}
 	p.PanelHolder.Paint(c)
 }

--- a/themes/dark/panel_tab.go
+++ b/themes/dark/panel_tab.go
@@ -36,7 +36,7 @@ func (t *PanelTab) SetActive(active bool) {
 }
 
 func (t *PanelTab) Paint(c gxui.Canvas) {
-	s := t.Bounds().Size()
+	s := t.Size()
 	var style Style
 	switch {
 	case t.IsMouseDown(gxui.MouseButtonLeft) && t.IsMouseOver():

--- a/themes/dark/progress_bar.go
+++ b/themes/dark/progress_bar.go
@@ -59,18 +59,18 @@ func (b *ProgressBar) animationTick() {
 	}
 }
 
-func (b *ProgressBar) Layout(r math.Rect) {
-	b.ProgressBar.Layout(r)
+func (b *ProgressBar) SetSize(size math.Size) {
+	b.ProgressBar.SetSize(size)
 
 	if b.chevrons != nil {
 		b.chevrons.Release()
 		b.chevrons = nil
 	}
-	if r.Size().Area() > 0 {
-		b.chevrons = b.theme.Driver().CreateCanvas(r.Size())
-		b.chevronWidth = r.H() / 2
+	if size.Area() > 0 {
+		b.chevrons = b.theme.Driver().CreateCanvas(size)
+		b.chevronWidth = size.H / 2
 		cw := b.chevronWidth
-		for x := -cw * 2; x < r.W(); x += cw * 2 {
+		for x := -cw * 2; x < size.W; x += cw * 2 {
 			// x0    x2
 			// |  x1 |  x3
 			//    |     |
@@ -81,7 +81,7 @@ func (b *ProgressBar) Layout(r math.Rect) {
 			//   /     /
 			//  /     /
 			// E-----D    - y2
-			y0, y1, y2 := 0, r.H()/2, r.H()
+			y0, y1, y2 := 0, size.H/2, size.H
 			x0, x1 := x, x+cw/2
 			x2, x3 := x0+cw, x1+cw
 			var chevron = gxui.Polygon{

--- a/themes/dark/textbox.go
+++ b/themes/dark/textbox.go
@@ -42,7 +42,7 @@ func (t *TextBox) Paint(c gxui.Canvas) {
 	t.TextBox.Paint(c)
 
 	if t.HasFocus() {
-		r := t.Bounds().Size().Rect()
+		r := t.Size().Rect()
 		s := t.theme.FocusedStyle
 		c.DrawRoundedRect(r, 3, 3, 3, 3, s.Pen, s.Brush)
 	}

--- a/themes/dark/tree.go
+++ b/themes/dark/tree.go
@@ -39,7 +39,7 @@ func CreateTree(theme *Theme) gxui.Tree {
 
 // mixins.Tree overrides
 func (t *Tree) Paint(c gxui.Canvas) {
-	r := t.Bounds().Size().Rect()
+	r := t.Size().Rect()
 
 	t.Tree.Paint(c)
 

--- a/viewport.go
+++ b/viewport.go
@@ -14,6 +14,11 @@ type Viewport interface {
 	// adjustments made with the SetScale method.
 	SizeDips() math.Size
 
+	// SetSizeDips sets the size of the viewport in device-independent pixels.
+	// The ratio of pixels to DIPs is based on the screen density and scale
+	// adjustments made with the SetScale method.
+	SetSizeDips(math.Size)
+
 	// SizePixels returns the size of the viewport in pixels.
 	SizePixels() math.Size
 


### PR DESCRIPTION
This CL moves the control offset relative to the parent out of the child and into the parent. This simplifies the layout and drawing logic for each control.

Fixes #25