### PR TITLE
Switch to more cross-platform goxjs/glfw.

### DIFF
--- a/drivers/gl/driver.go
+++ b/drivers/gl/driver.go
@@ -11,9 +11,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/go-gl/glfw/v3.1/glfw"
 	"github.com/google/gxui"
 	"github.com/google/gxui/math"
+	"github.com/goxjs/gl"
+	"github.com/goxjs/glfw"
 )
 
 // Maximum time allowed for application to process events on termination.
@@ -35,7 +36,7 @@ func StartDriver(appRoutine func(driver gxui.Driver)) {
 		runtime.GOMAXPROCS(2)
 	}
 
-	if err := glfw.Init(); err != nil {
+	if err := glfw.Init(gl.ContextWatcher); err != nil {
 		panic(err)
 	}
 	defer glfw.Terminate()

--- a/drivers/gl/keyboard_translate.go
+++ b/drivers/gl/keyboard_translate.go
@@ -7,7 +7,7 @@ package gl
 import (
 	"github.com/google/gxui"
 
-	"github.com/go-gl/glfw/v3.1/glfw"
+	"github.com/goxjs/glfw"
 )
 
 func translateKeyboardKey(in glfw.Key) gxui.KeyboardKey {

--- a/drivers/gl/mouse_translate.go
+++ b/drivers/gl/mouse_translate.go
@@ -6,9 +6,10 @@ package gl
 
 import (
 	"fmt"
+
 	"github.com/google/gxui"
 
-	"github.com/go-gl/glfw/v3.1/glfw"
+	"github.com/goxjs/glfw"
 )
 
 func translateMouseButton(button glfw.MouseButton) gxui.MouseButton {

--- a/drivers/gl/viewport.go
+++ b/drivers/gl/viewport.go
@@ -9,11 +9,11 @@ import (
 	"sync/atomic"
 	"unicode"
 
-	"github.com/go-gl/glfw/v3.1/glfw"
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl/platform"
 	"github.com/google/gxui/math"
 	"github.com/goxjs/gl"
+	"github.com/goxjs/glfw"
 )
 
 const viewportDebugEnabled = false
@@ -80,8 +80,9 @@ func newViewport(driver *driver, width, height int, title string, fullscreen boo
 	if err != nil {
 		panic(err)
 	}
+	width, height = wnd.GetSize() // At this time, width and height serve as a "hint" for glfw.CreateWindow, so get actual values from window.
+
 	wnd.MakeContextCurrent()
-	gl.ContextWatcher.OnMakeCurrent(nil)
 
 	v.context = newContext()
 
@@ -259,7 +260,6 @@ func (v *viewport) render() {
 	}
 
 	v.window.MakeContextCurrent()
-	gl.ContextWatcher.OnMakeCurrent(nil)
 
 	ctx := v.context
 	ctx.beginDraw(v.SizeDips(), v.SizePixels())
@@ -303,7 +303,6 @@ func (v *viewport) SetCanvas(cc gxui.Canvas) {
 	v.driver.asyncDriver(func() {
 		// Only use the canvas of the most recent SetCanvas call.
 		v.window.MakeContextCurrent()
-		gl.ContextWatcher.OnMakeCurrent(nil)
 		if atomic.LoadUint32(&v.redrawCount) == cnt {
 			if v.canvas != nil {
 				v.canvas.release()
@@ -438,7 +437,6 @@ func (v *viewport) Destroy() {
 	v.driver.asyncDriver(func() {
 		if !v.destroyed {
 			v.window.MakeContextCurrent()
-			gl.ContextWatcher.OnMakeCurrent(nil)
 			if v.canvas != nil {
 				v.canvas.Release()
 				v.canvas = nil


### PR DESCRIPTION
`goxjs/glfw` is a more cross-platform version of `glfw`, which adds a browser backend. This allows `gxui` to run in the browser, in addition to current desktop platforms (OS X, Linux, Windows).

This is a follow up to #86. Things seem to be quiet so I'll put this change up for initial review.

Resolves #49.