### PR TITLE
Add AssertUIGoroutine to the Driver interface.

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -39,4 +39,9 @@ type Driver interface {
 
 	CreateCanvas(math.Size) Canvas
 	CreateTexture(img image.Image, pixelsPerDip float32) Texture
+
+	// Debug function used to verify that the caller is executing on the UI
+	// go-routine. If the caller is not on the UI go-routine then the function
+	// panics.
+	AssertUIGoroutine()
 }

--- a/drivers/gl/debug.go
+++ b/drivers/gl/debug.go
@@ -1,0 +1,34 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gl
+
+import (
+	"runtime"
+	"strings"
+)
+
+// discoverUIGoRoutine finds and stores the program counter of the
+// function 'applicationLoop' that must be in the callstack. The
+// PC is stored so that AssertUIGoroutine can verify that the call
+// came from the application loop (the UI go-routine).
+func (d *driver) discoverUIGoRoutine() {
+	for _, pc := range d.pcs[:runtime.Callers(2, d.pcs)] {
+		name := runtime.FuncForPC(pc).Name()
+		if strings.HasSuffix(name, "applicationLoop") {
+			d.uiPC = pc
+			return
+		}
+	}
+	panic("applicationLoop was not found in the callstack")
+}
+
+func (d *driver) AssertUIGoroutine() {
+	for _, pc := range d.pcs[:runtime.Callers(2, d.pcs)] {
+		if pc == d.uiPC {
+			return
+		}
+	}
+	panic("AssertUIGoroutine called on a go-routine that was not the UI go-routine")
+}

--- a/mixins/base/container.go
+++ b/mixins/base/container.go
@@ -39,7 +39,7 @@ func (c *Container) Init(outer ContainerOuter, theme gxui.Theme) {
 	c.Container.Init(outer)
 	c.DrawPaint.Init(outer, theme)
 	c.InputEventHandler.Init(outer)
-	c.Layoutable.Init(outer)
+	c.Layoutable.Init(outer, theme)
 	c.Paddable.Init(outer)
 	c.PaintChildren.Init(outer)
 	c.Parentable.Init(outer)

--- a/mixins/base/control.go
+++ b/mixins/base/control.go
@@ -30,7 +30,7 @@ type Control struct {
 func (c *Control) Init(outer ControlOuter, theme gxui.Theme) {
 	c.Attachable.Init(outer)
 	c.DrawPaint.Init(outer, theme)
-	c.Layoutable.Init(outer)
+	c.Layoutable.Init(outer, theme)
 	c.InputEventHandler.Init(outer)
 	c.Parentable.Init(outer)
 	c.Visible.Init(outer)

--- a/mixins/parts/draw_paint.go
+++ b/mixins/parts/draw_paint.go
@@ -23,7 +23,7 @@ type DrawPaintOuter interface {
 
 type DrawPaint struct {
 	outer           DrawPaintOuter
-	theme           gxui.Theme
+	driver          gxui.Driver
 	canvas          gxui.Canvas
 	dirty           bool
 	redrawRequested bool
@@ -37,7 +37,7 @@ func verifyDetach(o DrawPaintOuter) {
 
 func (d *DrawPaint) Init(outer DrawPaintOuter, theme gxui.Theme) {
 	d.outer = outer
-	d.theme = theme
+	d.driver = theme.Driver()
 	outer.OnDetach(func() {
 		if d.canvas != nil {
 			d.canvas.Release()
@@ -51,6 +51,7 @@ func (d *DrawPaint) Init(outer DrawPaintOuter, theme gxui.Theme) {
 }
 
 func (d *DrawPaint) Redraw() {
+	d.driver.AssertUIGoroutine()
 	if !d.redrawRequested {
 		if p := d.outer.Parent(); p != nil {
 			d.redrawRequested = true
@@ -72,7 +73,7 @@ func (d *DrawPaint) Draw() gxui.Canvas {
 		if d.canvas != nil {
 			d.canvas.Release()
 		}
-		d.canvas = d.theme.Driver().CreateCanvas(s)
+		d.canvas = d.driver.CreateCanvas(s)
 		d.redrawRequested = false
 		d.outer.Paint(d.canvas)
 		d.canvas.Complete()

--- a/mixins/parts/layoutable.go
+++ b/mixins/parts/layoutable.go
@@ -7,6 +7,7 @@ package parts
 import (
 	"fmt"
 
+	"github.com/google/gxui"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/mixins/outer"
 )
@@ -18,14 +19,16 @@ type LayoutableOuter interface {
 
 type Layoutable struct {
 	outer             LayoutableOuter
+	driver            gxui.Driver
 	margin            math.Spacing
 	size              math.Size
 	relayoutRequested bool
 	inLayoutChildren  bool // True when calling LayoutChildren
 }
 
-func (l *Layoutable) Init(outer LayoutableOuter) {
+func (l *Layoutable) Init(outer LayoutableOuter, theme gxui.Theme) {
 	l.outer = outer
+	l.driver = theme.Driver()
 }
 
 func (l *Layoutable) SetMargin(m math.Spacing) {
@@ -63,6 +66,7 @@ func (l *Layoutable) SetSize(size math.Size) {
 }
 
 func (l *Layoutable) Relayout() {
+	l.driver.AssertUIGoroutine()
 	if l.inLayoutChildren {
 		panic("Cannot call Relayout() while in LayoutChildren")
 	}


### PR DESCRIPTION
This is can be used to assert that a function is being called on the UI
go-routine, which is expected for all of the controls.

AssertUIGoroutine is called from the two most commonly called internal
functions of controls: Redraw and Relayout.

Should catch race conditions in applications using GXUI.