### PR TITLE
Create a light theme.

### DIFF
--- a/samples/linear_layout/main.go
+++ b/samples/linear_layout/main.go
@@ -5,15 +5,26 @@
 package main
 
 import (
+	"flag"
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
-	"github.com/google/gxui/samples/flags"
 	"github.com/google/gxui/themes/dark"
+	"github.com/google/gxui/themes/light"
+)
+
+var (
+	flagTheme          = flag.String("theme", "dark", "Theme to use {dark|light}.")
+	defaultScaleFactor = flag.Float64("scaling", 1.0, "Adjusts the scaling of UI rendering")
 )
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	var theme gxui.Theme
+	if *flagTheme == "light" {
+		theme = light.CreateTheme(driver)
+	} else {
+		theme = dark.CreateTheme(driver)
+	}
 
 	layout := theme.CreateLinearLayout()
 	layout.SetSizeMode(gxui.Fill)
@@ -80,12 +91,13 @@ func appMain(driver gxui.Driver) {
 	update()
 
 	window := theme.CreateWindow(800, 600, "Linear layout")
-	window.SetScale(flags.DefaultScaleFactor)
+	window.SetScale(float32(*defaultScaleFactor))
 	window.AddChild(layout)
 	window.OnClose(driver.Terminate)
 	window.SetPadding(math.Spacing{L: 10, T: 10, R: 10, B: 10})
 }
 
 func main() {
+	flag.Parse()
 	gl.StartDriver(appMain)
 }

--- a/theme.go
+++ b/theme.go
@@ -8,6 +8,8 @@ type Theme interface {
 	Driver() Driver
 	DefaultFont() Font
 	SetDefaultFont(Font)
+	DefaultMonospaceFont() Font
+	SetDefaultMonospaceFont(Font)
 	CreateBubbleOverlay() BubbleOverlay
 	CreateButton() Button
 	CreateCodeEditor() CodeEditor

--- a/themes/basic/bubble_overlay.go
+++ b/themes/basic/bubble_overlay.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/basic/button.go
+++ b/themes/basic/button.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/basic/code_editor.go
+++ b/themes/basic/code_editor.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
@@ -18,7 +18,7 @@ type CodeEditor struct {
 func CreateCodeEditor(theme *Theme) gxui.CodeEditor {
 	t := &CodeEditor{}
 	t.theme = theme
-	t.Init(t, theme.driver, theme, theme.defaultMonospaceFont)
+	t.Init(t, theme.Driver(), theme, theme.DefaultMonospaceFont())
 	t.SetTextColor(theme.TextBoxDefaultStyle.FontColor)
 	t.SetMargin(math.Spacing{L: 3, T: 3, R: 3, B: 3})
 	t.SetPadding(math.Spacing{L: 3, T: 3, R: 3, B: 3})

--- a/themes/basic/colors.go
+++ b/themes/basic/colors.go
@@ -2,15 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
-	"github.com/google/gxui/mixins"
 )
 
-func CreateScrollLayout(theme *Theme) gxui.ScrollLayout {
-	l := &mixins.ScrollLayout{}
-	l.Init(l, theme)
-	return l
-}
+var Blue30 = gxui.Color{R: 0.0, G: 0.0, B: 0.3, A: 1.0}

--- a/themes/basic/drop_down_list.go
+++ b/themes/basic/drop_down_list.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
@@ -10,35 +10,40 @@ import (
 	"github.com/google/gxui/mixins"
 )
 
-type List struct {
-	mixins.List
+type DropDownList struct {
+	mixins.DropDownList
 	theme *Theme
 }
 
-func CreateList(theme *Theme) gxui.List {
-	l := &List{}
+func CreateDropDownList(theme *Theme) gxui.DropDownList {
+	l := &DropDownList{}
 	l.Init(l, theme)
 	l.OnGainedFocus(l.Redraw)
 	l.OnLostFocus(l.Redraw)
+	l.List().OnAttach(l.Redraw)
+	l.List().OnDetach(l.Redraw)
+	l.OnMouseEnter(func(gxui.MouseEvent) {
+		l.SetBorderPen(theme.DropDownListOverStyle.Pen)
+	})
+	l.OnMouseExit(func(gxui.MouseEvent) {
+		l.SetBorderPen(theme.DropDownListDefaultStyle.Pen)
+	})
 	l.SetPadding(math.CreateSpacing(2))
-	l.SetBorderPen(gxui.TransparentPen)
+	l.SetBorderPen(theme.DropDownListDefaultStyle.Pen)
+	l.SetBackgroundBrush(theme.DropDownListDefaultStyle.Brush)
 	l.theme = theme
 	return l
 }
 
 // mixin.List overrides
-func (l *List) Paint(c gxui.Canvas) {
-	l.List.Paint(c)
-	if l.HasFocus() {
+func (l *DropDownList) Paint(c gxui.Canvas) {
+	l.DropDownList.Paint(c)
+	if l.HasFocus() || l.ListShowing() {
 		r := l.Size().Rect().ContractI(1)
 		c.DrawRoundedRect(r, 3.0, 3.0, 3.0, 3.0, l.theme.FocusedStyle.Pen, l.theme.FocusedStyle.Brush)
 	}
 }
 
-func (l *List) PaintSelection(c gxui.Canvas, r math.Rect) {
+func (l *DropDownList) DrawSelection(c gxui.Canvas, r math.Rect) {
 	c.DrawRoundedRect(r, 2.0, 2.0, 2.0, 2.0, l.theme.HighlightStyle.Pen, l.theme.HighlightStyle.Brush)
-}
-
-func (l *List) PaintMouseOverBackground(c gxui.Canvas, r math.Rect) {
-	c.DrawRoundedRect(r, 2.0, 2.0, 2.0, 2.0, gxui.TransparentPen, gxui.CreateBrush(gxui.Gray15))
 }

--- a/themes/basic/image.go
+++ b/themes/basic/image.go
@@ -2,10 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
+	"github.com/google/gxui/mixins"
 )
 
-var Blue30 = gxui.Color{R: 0.0, G: 0.0, B: 0.3, A: 1.0}
+func CreateImage(theme *Theme) gxui.Image {
+	i := &mixins.Image{}
+	i.Init(i, theme)
+	return i
+}

--- a/themes/basic/label.go
+++ b/themes/basic/label.go
@@ -2,15 +2,17 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
+	"github.com/google/gxui/math"
 	"github.com/google/gxui/mixins"
 )
 
-func CreateLinearLayout(theme *Theme) gxui.LinearLayout {
-	l := &mixins.LinearLayout{}
-	l.Init(l, theme)
+func CreateLabel(theme *Theme) gxui.Label {
+	l := &mixins.Label{}
+	l.Init(l, theme, theme.DefaultFont(), theme.LabelStyle.FontColor)
+	l.SetMargin(math.Spacing{L: 3, T: 3, R: 3, B: 3})
 	return l
 }

--- a/themes/basic/linear_layout.go
+++ b/themes/basic/linear_layout.go
@@ -2,17 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
-	"github.com/google/gxui/math"
 	"github.com/google/gxui/mixins"
 )
 
-func CreateLabel(theme *Theme) gxui.Label {
-	l := &mixins.Label{}
-	l.Init(l, theme, theme.defaultFont, theme.LabelStyle.FontColor)
-	l.SetMargin(math.Spacing{L: 3, T: 3, R: 3, B: 3})
+func CreateLinearLayout(theme *Theme) gxui.LinearLayout {
+	l := &mixins.LinearLayout{}
+	l.Init(l, theme)
 	return l
 }

--- a/themes/basic/list.go
+++ b/themes/basic/list.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
@@ -10,40 +10,35 @@ import (
 	"github.com/google/gxui/mixins"
 )
 
-type DropDownList struct {
-	mixins.DropDownList
+type List struct {
+	mixins.List
 	theme *Theme
 }
 
-func CreateDropDownList(theme *Theme) gxui.DropDownList {
-	l := &DropDownList{}
+func CreateList(theme *Theme) gxui.List {
+	l := &List{}
 	l.Init(l, theme)
 	l.OnGainedFocus(l.Redraw)
 	l.OnLostFocus(l.Redraw)
-	l.List().OnAttach(l.Redraw)
-	l.List().OnDetach(l.Redraw)
-	l.OnMouseEnter(func(gxui.MouseEvent) {
-		l.SetBorderPen(theme.DropDownListOverStyle.Pen)
-	})
-	l.OnMouseExit(func(gxui.MouseEvent) {
-		l.SetBorderPen(theme.DropDownListDefaultStyle.Pen)
-	})
 	l.SetPadding(math.CreateSpacing(2))
-	l.SetBorderPen(theme.DropDownListDefaultStyle.Pen)
-	l.SetBackgroundBrush(theme.DropDownListDefaultStyle.Brush)
+	l.SetBorderPen(gxui.TransparentPen)
 	l.theme = theme
 	return l
 }
 
 // mixin.List overrides
-func (l *DropDownList) Paint(c gxui.Canvas) {
-	l.DropDownList.Paint(c)
-	if l.HasFocus() || l.ListShowing() {
+func (l *List) Paint(c gxui.Canvas) {
+	l.List.Paint(c)
+	if l.HasFocus() {
 		r := l.Size().Rect().ContractI(1)
 		c.DrawRoundedRect(r, 3.0, 3.0, 3.0, 3.0, l.theme.FocusedStyle.Pen, l.theme.FocusedStyle.Brush)
 	}
 }
 
-func (l *DropDownList) DrawSelection(c gxui.Canvas, r math.Rect) {
+func (l *List) PaintSelection(c gxui.Canvas, r math.Rect) {
 	c.DrawRoundedRect(r, 2.0, 2.0, 2.0, 2.0, l.theme.HighlightStyle.Pen, l.theme.HighlightStyle.Brush)
+}
+
+func (l *List) PaintMouseOverBackground(c gxui.Canvas, r math.Rect) {
+	c.DrawRoundedRect(r, 2.0, 2.0, 2.0, 2.0, gxui.TransparentPen, gxui.CreateBrush(gxui.Gray15))
 }

--- a/themes/basic/panel_holder.go
+++ b/themes/basic/panel_holder.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/basic/panel_tab.go
+++ b/themes/basic/panel_tab.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/basic/progress_bar.go
+++ b/themes/basic/progress_bar.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"time"

--- a/themes/basic/scroll_bar.go
+++ b/themes/basic/scroll_bar.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/basic/scroll_layout.go
+++ b/themes/basic/scroll_layout.go
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
 	"github.com/google/gxui/mixins"
 )
 
-func CreateImage(theme *Theme) gxui.Image {
-	i := &mixins.Image{}
-	i.Init(i, theme)
-	return i
+func CreateScrollLayout(theme *Theme) gxui.ScrollLayout {
+	l := &mixins.ScrollLayout{}
+	l.Init(l, theme)
+	return l
 }

--- a/themes/basic/splitter_layout.go
+++ b/themes/basic/splitter_layout.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/basic/style.go
+++ b/themes/basic/style.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/basic/textbox.go
+++ b/themes/basic/textbox.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"
@@ -17,7 +17,7 @@ type TextBox struct {
 
 func CreateTextBox(theme *Theme) gxui.TextBox {
 	t := &TextBox{}
-	t.Init(t, theme.driver, theme, theme.defaultFont)
+	t.Init(t, theme.Driver(), theme, theme.DefaultFont())
 	t.SetTextColor(theme.TextBoxDefaultStyle.FontColor)
 	t.SetMargin(math.Spacing{L: 3, T: 3, R: 3, B: 3})
 	t.SetPadding(math.Spacing{L: 3, T: 3, R: 3, B: 3})

--- a/themes/basic/theme.go
+++ b/themes/basic/theme.go
@@ -1,0 +1,126 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package basic
+
+import (
+	"github.com/google/gxui"
+)
+
+type Theme struct {
+	DriverInfo               gxui.Driver
+	DefaultFontInfo          gxui.Font
+	DefaultMonospaceFontInfo gxui.Font
+
+	WindowBackground gxui.Color
+
+	BubbleOverlayStyle        Style
+	ButtonDefaultStyle        Style
+	ButtonOverStyle           Style
+	ButtonPressedStyle        Style
+	CodeSuggestionListStyle   Style
+	DropDownListDefaultStyle  Style
+	DropDownListOverStyle     Style
+	FocusedStyle              Style
+	HighlightStyle            Style
+	LabelStyle                Style
+	PanelBackgroundStyle      Style
+	ScrollBarBarDefaultStyle  Style
+	ScrollBarBarOverStyle     Style
+	ScrollBarRailDefaultStyle Style
+	ScrollBarRailOverStyle    Style
+	SplitterBarDefaultStyle   Style
+	SplitterBarOverStyle      Style
+	TabActiveHighlightStyle   Style
+	TabDefaultStyle           Style
+	TabOverStyle              Style
+	TabPressedStyle           Style
+	TextBoxDefaultStyle       Style
+	TextBoxOverStyle          Style
+}
+
+// gxui.Theme compliance
+func (t *Theme) Driver() gxui.Driver {
+	return t.DriverInfo
+}
+
+func (t *Theme) DefaultFont() gxui.Font {
+	return t.DefaultFontInfo
+}
+
+func (t *Theme) SetDefaultFont(f gxui.Font) {
+	t.DefaultFontInfo = f
+}
+
+func (t *Theme) DefaultMonospaceFont() gxui.Font {
+	return t.DefaultMonospaceFontInfo
+}
+
+func (t *Theme) SetDefaultMonospaceFont(f gxui.Font) {
+	t.DefaultMonospaceFontInfo = f
+}
+
+func (t *Theme) CreateBubbleOverlay() gxui.BubbleOverlay {
+	return CreateBubbleOverlay(t)
+}
+
+func (t *Theme) CreateButton() gxui.Button {
+	return CreateButton(t)
+}
+
+func (t *Theme) CreateCodeEditor() gxui.CodeEditor {
+	return CreateCodeEditor(t)
+}
+
+func (t *Theme) CreateDropDownList() gxui.DropDownList {
+	return CreateDropDownList(t)
+}
+
+func (t *Theme) CreateImage() gxui.Image {
+	return CreateImage(t)
+}
+
+func (t *Theme) CreateLabel() gxui.Label {
+	return CreateLabel(t)
+}
+
+func (t *Theme) CreateLinearLayout() gxui.LinearLayout {
+	return CreateLinearLayout(t)
+}
+
+func (t *Theme) CreateList() gxui.List {
+	return CreateList(t)
+}
+
+func (t *Theme) CreatePanelHolder() gxui.PanelHolder {
+	return CreatePanelHolder(t)
+}
+
+func (t *Theme) CreateProgressBar() gxui.ProgressBar {
+	return CreateProgressBar(t)
+}
+
+func (t *Theme) CreateScrollBar() gxui.ScrollBar {
+	return CreateScrollBar(t)
+}
+
+func (t *Theme) CreateScrollLayout() gxui.ScrollLayout {
+	return CreateScrollLayout(t)
+}
+
+func (t *Theme) CreateSplitterLayout() gxui.SplitterLayout {
+	return CreateSplitterLayout(t)
+}
+
+func (t *Theme) CreateTextBox() gxui.TextBox {
+	return CreateTextBox(t)
+}
+
+func (t *Theme) CreateTree() gxui.Tree {
+	return CreateTree(t)
+}
+
+func (t *Theme) CreateWindow(width, height int, title string) gxui.Window {
+	return CreateWindow(t, width, height, title)
+}

--- a/themes/basic/tree.go
+++ b/themes/basic/tree.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/basic/window.go
+++ b/themes/basic/window.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package dark
+package basic
 
 import (
 	"github.com/google/gxui"

--- a/themes/dark/theme.go
+++ b/themes/dark/theme.go
@@ -9,39 +9,8 @@ import (
 
 	"github.com/google/gxui"
 	"github.com/google/gxui/gxfont"
+	"github.com/google/gxui/themes/basic"
 )
-
-type Theme struct {
-	driver               gxui.Driver
-	defaultFont          gxui.Font
-	defaultMonospaceFont gxui.Font
-
-	WindowBackground gxui.Color
-
-	BubbleOverlayStyle        Style
-	ButtonDefaultStyle        Style
-	ButtonOverStyle           Style
-	ButtonPressedStyle        Style
-	CodeSuggestionListStyle   Style
-	DropDownListDefaultStyle  Style
-	DropDownListOverStyle     Style
-	FocusedStyle              Style
-	HighlightStyle            Style
-	LabelStyle                Style
-	PanelBackgroundStyle      Style
-	ScrollBarBarDefaultStyle  Style
-	ScrollBarBarOverStyle     Style
-	ScrollBarRailDefaultStyle Style
-	ScrollBarRailOverStyle    Style
-	SplitterBarDefaultStyle   Style
-	SplitterBarOverStyle      Style
-	TabActiveHighlightStyle   Style
-	TabDefaultStyle           Style
-	TabOverStyle              Style
-	TabPressedStyle           Style
-	TextBoxDefaultStyle       Style
-	TextBoxOverStyle          Style
-}
 
 func CreateTheme(driver gxui.Driver) gxui.Theme {
 	defaultFont, err := driver.CreateFont(gxfont.Default, 12)
@@ -67,112 +36,35 @@ func CreateTheme(driver gxui.Driver) gxui.Theme {
 	neonBlue := gxui.ColorFromHex(0xFF5C8CFF)
 	focus := gxui.ColorFromHex(0xA0C4D6FF)
 
-	return &Theme{
-		driver:               driver,
-		defaultFont:          defaultFont,
-		defaultMonospaceFont: defaultMonospaceFont,
-		WindowBackground:     gxui.Black,
+	return &basic.Theme{
+		DriverInfo:               driver,
+		DefaultFontInfo:          defaultFont,
+		DefaultMonospaceFontInfo: defaultMonospaceFont,
+		WindowBackground:         gxui.Black,
 
 		//                                   fontColor    brushColor   penColor
-		BubbleOverlayStyle:        CreateStyle(gxui.Gray80, gxui.Gray20, gxui.Gray40, 1.0),
-		ButtonDefaultStyle:        CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray20, 1.0),
-		ButtonOverStyle:           CreateStyle(gxui.Gray90, gxui.Gray15, gxui.Gray50, 1.0),
-		ButtonPressedStyle:        CreateStyle(gxui.Gray20, gxui.Gray70, gxui.Gray30, 1.0),
-		CodeSuggestionListStyle:   CreateStyle(gxui.Gray80, gxui.Gray20, gxui.Gray10, 1.0),
-		DropDownListDefaultStyle:  CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray20, 1.0),
-		DropDownListOverStyle:     CreateStyle(gxui.Gray80, gxui.Gray15, gxui.Gray50, 1.0),
-		FocusedStyle:              CreateStyle(gxui.Gray80, gxui.Transparent, focus, 1.0),
-		HighlightStyle:            CreateStyle(gxui.Gray80, gxui.Transparent, neonBlue, 2.0),
-		LabelStyle:                CreateStyle(gxui.Gray80, gxui.Transparent, gxui.Transparent, 0.0),
-		PanelBackgroundStyle:      CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray15, 1.0),
-		ScrollBarBarDefaultStyle:  CreateStyle(gxui.Gray80, gxui.Gray30, gxui.Gray40, 1.0),
-		ScrollBarBarOverStyle:     CreateStyle(gxui.Gray80, gxui.Gray50, gxui.Gray60, 1.0),
-		ScrollBarRailDefaultStyle: CreateStyle(gxui.Gray80, scrollBarRailDefaultBg, gxui.Transparent, 1.0),
-		ScrollBarRailOverStyle:    CreateStyle(gxui.Gray80, scrollBarRailOverBg, gxui.Gray20, 1.0),
-		SplitterBarDefaultStyle:   CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray10, 1.0),
-		SplitterBarOverStyle:      CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray50, 1.0),
-		TabActiveHighlightStyle:   CreateStyle(gxui.Gray90, neonBlue, neonBlue, 0.0),
-		TabDefaultStyle:           CreateStyle(gxui.Gray80, gxui.Gray30, gxui.Gray40, 1.0),
-		TabOverStyle:              CreateStyle(gxui.Gray90, gxui.Gray30, gxui.Gray50, 1.0),
-		TabPressedStyle:           CreateStyle(gxui.Gray20, gxui.Gray70, gxui.Gray30, 1.0),
-		TextBoxDefaultStyle:       CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray20, 1.0),
-		TextBoxOverStyle:          CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray50, 1.0),
+		BubbleOverlayStyle:        basic.CreateStyle(gxui.Gray80, gxui.Gray20, gxui.Gray40, 1.0),
+		ButtonDefaultStyle:        basic.CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray20, 1.0),
+		ButtonOverStyle:           basic.CreateStyle(gxui.Gray90, gxui.Gray15, gxui.Gray50, 1.0),
+		ButtonPressedStyle:        basic.CreateStyle(gxui.Gray20, gxui.Gray70, gxui.Gray30, 1.0),
+		CodeSuggestionListStyle:   basic.CreateStyle(gxui.Gray80, gxui.Gray20, gxui.Gray10, 1.0),
+		DropDownListDefaultStyle:  basic.CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray20, 1.0),
+		DropDownListOverStyle:     basic.CreateStyle(gxui.Gray80, gxui.Gray15, gxui.Gray50, 1.0),
+		FocusedStyle:              basic.CreateStyle(gxui.Gray80, gxui.Transparent, focus, 1.0),
+		HighlightStyle:            basic.CreateStyle(gxui.Gray80, gxui.Transparent, neonBlue, 2.0),
+		LabelStyle:                basic.CreateStyle(gxui.Gray80, gxui.Transparent, gxui.Transparent, 0.0),
+		PanelBackgroundStyle:      basic.CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray15, 1.0),
+		ScrollBarBarDefaultStyle:  basic.CreateStyle(gxui.Gray80, gxui.Gray30, gxui.Gray40, 1.0),
+		ScrollBarBarOverStyle:     basic.CreateStyle(gxui.Gray80, gxui.Gray50, gxui.Gray60, 1.0),
+		ScrollBarRailDefaultStyle: basic.CreateStyle(gxui.Gray80, scrollBarRailDefaultBg, gxui.Transparent, 1.0),
+		ScrollBarRailOverStyle:    basic.CreateStyle(gxui.Gray80, scrollBarRailOverBg, gxui.Gray20, 1.0),
+		SplitterBarDefaultStyle:   basic.CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray10, 1.0),
+		SplitterBarOverStyle:      basic.CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray50, 1.0),
+		TabActiveHighlightStyle:   basic.CreateStyle(gxui.Gray90, neonBlue, neonBlue, 0.0),
+		TabDefaultStyle:           basic.CreateStyle(gxui.Gray80, gxui.Gray30, gxui.Gray40, 1.0),
+		TabOverStyle:              basic.CreateStyle(gxui.Gray90, gxui.Gray30, gxui.Gray50, 1.0),
+		TabPressedStyle:           basic.CreateStyle(gxui.Gray20, gxui.Gray70, gxui.Gray30, 1.0),
+		TextBoxDefaultStyle:       basic.CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray20, 1.0),
+		TextBoxOverStyle:          basic.CreateStyle(gxui.Gray80, gxui.Gray10, gxui.Gray50, 1.0),
 	}
-}
-
-// gxui.Theme compliance
-func (t *Theme) Driver() gxui.Driver {
-	return t.driver
-}
-
-func (t *Theme) DefaultFont() gxui.Font {
-	return t.defaultFont
-}
-
-func (t *Theme) SetDefaultFont(f gxui.Font) {
-	t.defaultFont = f
-}
-
-func (t *Theme) CreateBubbleOverlay() gxui.BubbleOverlay {
-	return CreateBubbleOverlay(t)
-}
-
-func (t *Theme) CreateButton() gxui.Button {
-	return CreateButton(t)
-}
-
-func (t *Theme) CreateCodeEditor() gxui.CodeEditor {
-	return CreateCodeEditor(t)
-}
-
-func (t *Theme) CreateDropDownList() gxui.DropDownList {
-	return CreateDropDownList(t)
-}
-
-func (t *Theme) CreateImage() gxui.Image {
-	return CreateImage(t)
-}
-
-func (t *Theme) CreateLabel() gxui.Label {
-	return CreateLabel(t)
-}
-
-func (t *Theme) CreateLinearLayout() gxui.LinearLayout {
-	return CreateLinearLayout(t)
-}
-
-func (t *Theme) CreateList() gxui.List {
-	return CreateList(t)
-}
-
-func (t *Theme) CreatePanelHolder() gxui.PanelHolder {
-	return CreatePanelHolder(t)
-}
-
-func (t *Theme) CreateProgressBar() gxui.ProgressBar {
-	return CreateProgressBar(t)
-}
-
-func (t *Theme) CreateScrollBar() gxui.ScrollBar {
-	return CreateScrollBar(t)
-}
-
-func (t *Theme) CreateScrollLayout() gxui.ScrollLayout {
-	return CreateScrollLayout(t)
-}
-
-func (t *Theme) CreateSplitterLayout() gxui.SplitterLayout {
-	return CreateSplitterLayout(t)
-}
-
-func (t *Theme) CreateTextBox() gxui.TextBox {
-	return CreateTextBox(t)
-}
-
-func (t *Theme) CreateTree() gxui.Tree {
-	return CreateTree(t)
-}
-
-func (t *Theme) CreateWindow(width, height int, title string) gxui.Window {
-	return CreateWindow(t, width, height, title)
 }

--- a/themes/light/theme.go
+++ b/themes/light/theme.go
@@ -1,0 +1,70 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package light
+
+import (
+	"fmt"
+
+	"github.com/google/gxui"
+	"github.com/google/gxui/gxfont"
+	"github.com/google/gxui/themes/basic"
+)
+
+func CreateTheme(driver gxui.Driver) gxui.Theme {
+	defaultFont, err := driver.CreateFont(gxfont.Default, 12)
+	if err == nil {
+		defaultFont.LoadGlyphs(32, 126)
+	} else {
+		fmt.Printf("Warning: Failed to load default font - %v\n", err)
+	}
+
+	defaultMonospaceFont, err := driver.CreateFont(gxfont.Monospace, 12)
+	if err == nil {
+		defaultFont.LoadGlyphs(32, 126)
+	} else {
+		fmt.Printf("Warning: Failed to load default monospace font - %v\n", err)
+	}
+
+	scrollBarRailDefaultBg := gxui.Black
+	scrollBarRailDefaultBg.A = 0.7
+
+	scrollBarRailOverBg := gxui.Gray20
+	scrollBarRailOverBg.A = 0.7
+
+	neonBlue := gxui.ColorFromHex(0xFF5C8CFF)
+	focus := gxui.ColorFromHex(0xFFC4D6FF)
+
+	return &basic.Theme{
+		DriverInfo:               driver,
+		DefaultFontInfo:          defaultFont,
+		DefaultMonospaceFontInfo: defaultMonospaceFont,
+		WindowBackground:         gxui.White,
+
+		//                                   fontColor    brushColor   penColor
+		BubbleOverlayStyle:        basic.CreateStyle(gxui.Gray40, gxui.Gray20, gxui.Gray40, 1.0),
+		ButtonDefaultStyle:        basic.CreateStyle(gxui.Gray40, gxui.White, gxui.Gray40, 1.0),
+		ButtonOverStyle:           basic.CreateStyle(gxui.Gray40, gxui.Gray90, gxui.Gray40, 1.0),
+		ButtonPressedStyle:        basic.CreateStyle(gxui.Gray20, gxui.Gray70, gxui.Gray30, 1.0),
+		CodeSuggestionListStyle:   basic.CreateStyle(gxui.Gray40, gxui.Gray20, gxui.Gray10, 1.0),
+		DropDownListDefaultStyle:  basic.CreateStyle(gxui.Gray40, gxui.White, gxui.Gray20, 1.0),
+		DropDownListOverStyle:     basic.CreateStyle(gxui.Gray40, gxui.Gray90, gxui.Gray50, 1.0),
+		FocusedStyle:              basic.CreateStyle(gxui.Gray20, gxui.Transparent, focus, 1.0),
+		HighlightStyle:            basic.CreateStyle(gxui.Gray40, gxui.Transparent, neonBlue, 2.0),
+		LabelStyle:                basic.CreateStyle(gxui.Gray40, gxui.Transparent, gxui.Transparent, 0.0),
+		PanelBackgroundStyle:      basic.CreateStyle(gxui.Gray40, gxui.White, gxui.Gray15, 1.0),
+		ScrollBarBarDefaultStyle:  basic.CreateStyle(gxui.Gray40, gxui.Gray30, gxui.Gray40, 1.0),
+		ScrollBarBarOverStyle:     basic.CreateStyle(gxui.Gray40, gxui.Gray50, gxui.Gray60, 1.0),
+		ScrollBarRailDefaultStyle: basic.CreateStyle(gxui.Gray40, scrollBarRailDefaultBg, gxui.Transparent, 1.0),
+		ScrollBarRailOverStyle:    basic.CreateStyle(gxui.Gray40, scrollBarRailOverBg, gxui.Gray20, 1.0),
+		SplitterBarDefaultStyle:   basic.CreateStyle(gxui.Gray40, gxui.Gray80, gxui.Gray40, 1.0),
+		SplitterBarOverStyle:      basic.CreateStyle(gxui.Gray40, gxui.Gray80, gxui.Gray50, 1.0),
+		TabActiveHighlightStyle:   basic.CreateStyle(gxui.Gray30, neonBlue, neonBlue, 0.0),
+		TabDefaultStyle:           basic.CreateStyle(gxui.Gray40, gxui.White, gxui.Gray40, 1.0),
+		TabOverStyle:              basic.CreateStyle(gxui.Gray30, gxui.Gray90, gxui.Gray50, 1.0),
+		TabPressedStyle:           basic.CreateStyle(gxui.Gray20, gxui.Gray70, gxui.Gray30, 1.0),
+		TextBoxDefaultStyle:       basic.CreateStyle(gxui.Gray40, gxui.White, gxui.Gray20, 1.0),
+		TextBoxOverStyle:          basic.CreateStyle(gxui.Gray40, gxui.White, gxui.Gray50, 1.0),
+	}
+}


### PR DESCRIPTION
This CL moves the current themes/dark to themes/basic. It then creates
a themes/dark and themes/light which both use themes/basic and implement the
CreateTheme method to set the desired theme colours.

The colours used in the light theme are the colours from:
https://github.com/google/gxui/pull/129.

The linear_layout test has been modified to have a -theme argument. It
defaults to dark but dark or light can be passed to set the theme.

BUG=#128