### PR TITLE
Add theme flag handling to all samples.

### DIFF
--- a/samples/file_dlg/main.go
+++ b/samples/file_dlg/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/samples/file_dlg/roots"
 	"github.com/google/gxui/samples/flags"
-	"github.com/google/gxui/themes/dark"
 )
 
 var (
@@ -171,7 +170,7 @@ func (a directoryAdapter) Create(theme gxui.Theme, index int) gxui.Control {
 }
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 
 	window := theme.CreateWindow(800, 600, "Open file...")
 	window.SetScale(flags.DefaultScaleFactor)

--- a/samples/flags/flags.go
+++ b/samples/flags/flags.go
@@ -5,13 +5,30 @@
 // Package flags holds command line options common to all GXUI samples.
 package flags
 
-import "flag"
+import (
+	"flag"
+	"github.com/google/gxui"
+	"github.com/google/gxui/themes/dark"
+	"github.com/google/gxui/themes/light"
+)
 
 var DefaultScaleFactor float32
+var FlagTheme string
 
 func init() {
+	flagTheme := flag.String("theme", "dark", "Theme to use {dark|light}.")
 	defaultScaleFactor := flag.Float64("scaling", 1.0, "Adjusts the scaling of UI rendering")
 	flag.Parse()
 
 	DefaultScaleFactor = float32(*defaultScaleFactor)
+	FlagTheme = *flagTheme
+}
+
+// CreateTheme creates and returns the theme specified on the command line.
+// The default theme is dark.
+func CreateTheme(driver gxui.Driver) gxui.Theme {
+	if FlagTheme == "light" {
+		return light.CreateTheme(driver)
+	}
+	return dark.CreateTheme(driver)
 }

--- a/samples/fullscreen/main.go
+++ b/samples/fullscreen/main.go
@@ -9,11 +9,10 @@ import (
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/samples/flags"
-	"github.com/google/gxui/themes/dark"
 )
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 
 	window := theme.CreateWindow(200, 150, "Window")
 	window.OnClose(driver.Terminate)

--- a/samples/hello_world/main.go
+++ b/samples/hello_world/main.go
@@ -11,11 +11,11 @@ import (
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/gxfont"
 	"github.com/google/gxui/math"
-	"github.com/google/gxui/themes/dark"
+	"github.com/google/gxui/samples/flags"
 )
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 
 	font, err := driver.CreateFont(gxfont.Default, 75)
 	if err != nil {

--- a/samples/image_viewer/main.go
+++ b/samples/image_viewer/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/samples/flags"
-	"github.com/google/gxui/themes/dark"
 )
 
 func appMain(driver gxui.Driver) {
@@ -39,7 +38,7 @@ func appMain(driver gxui.Driver) {
 		os.Exit(1)
 	}
 
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 	img := theme.CreateImage()
 
 	mx := source.Bounds().Max

--- a/samples/linear_layout/main.go
+++ b/samples/linear_layout/main.go
@@ -5,27 +5,14 @@
 package main
 
 import (
-	"flag"
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
-	"github.com/google/gxui/themes/dark"
-	"github.com/google/gxui/themes/light"
-)
-
-var (
-	flagTheme          = flag.String("theme", "dark", "Theme to use {dark|light}.")
-	defaultScaleFactor = flag.Float64("scaling", 1.0, "Adjusts the scaling of UI rendering")
+	"github.com/google/gxui/samples/flags"
 )
 
 func appMain(driver gxui.Driver) {
-	var theme gxui.Theme
-	if *flagTheme == "light" {
-		theme = light.CreateTheme(driver)
-	} else {
-		theme = dark.CreateTheme(driver)
-	}
-
+	theme := flags.CreateTheme(driver)
 	layout := theme.CreateLinearLayout()
 	layout.SetSizeMode(gxui.Fill)
 
@@ -91,13 +78,12 @@ func appMain(driver gxui.Driver) {
 	update()
 
 	window := theme.CreateWindow(800, 600, "Linear layout")
-	window.SetScale(float32(*defaultScaleFactor))
+	window.SetScale(flags.DefaultScaleFactor)
 	window.AddChild(layout)
 	window.OnClose(driver.Terminate)
 	window.SetPadding(math.Spacing{L: 10, T: 10, R: 10, B: 10})
 }
 
 func main() {
-	flag.Parse()
 	gl.StartDriver(appMain)
 }

--- a/samples/lists/main.go
+++ b/samples/lists/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/samples/flags"
-	"github.com/google/gxui/themes/dark"
 )
 
 // Number picker uses the gxui.DefaultAdapter for driving a list
@@ -149,7 +148,7 @@ func colorPicker(theme gxui.Theme) gxui.Control {
 }
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 
 	overlay := theme.CreateBubbleOverlay()
 

--- a/samples/panels/main.go
+++ b/samples/panels/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/google/gxui"
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/samples/flags"
-	"github.com/google/gxui/themes/dark"
 )
 
 // Create a PanelHolder with a 3 panels
@@ -27,7 +26,7 @@ func panelHolder(name string, theme gxui.Theme) gxui.PanelHolder {
 }
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 
 	// ┌───────┐║┌───────┐
 	// │       │║│       │

--- a/samples/polygon/main.go
+++ b/samples/polygon/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/samples/flags"
-	"github.com/google/gxui/themes/dark"
 )
 
 func drawStar(canvas gxui.Canvas, center math.Point, radius, rotation float32, points int) {
@@ -59,7 +58,7 @@ func drawMoon(canvas gxui.Canvas, center math.Point, radius float32) {
 }
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 	window := theme.CreateWindow(800, 600, "Polygon")
 	window.SetScale(flags.DefaultScaleFactor)
 

--- a/samples/progress_bar/main.go
+++ b/samples/progress_bar/main.go
@@ -11,11 +11,10 @@ import (
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/samples/flags"
-	"github.com/google/gxui/themes/dark"
 )
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 
 	label := theme.CreateLabel()
 	label.SetText("This is a progress bar:")

--- a/samples/tree/main.go
+++ b/samples/tree/main.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/gxui/drivers/gl"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/samples/flags"
-	"github.com/google/gxui/themes/dark"
 )
 
 // item is used as an gxui.AdapterItem to identifiy each of the nodes.
@@ -162,7 +161,7 @@ func addSpecies(animals *node) map[string]item {
 }
 
 func appMain(driver gxui.Driver) {
-	theme := dark.CreateTheme(driver)
+	theme := flags.CreateTheme(driver)
 
 	layout := theme.CreateLinearLayout()
 	layout.SetDirection(gxui.TopToBottom)


### PR DESCRIPTION
This CL updates the sample code to move the theme selection into flags
and uses flags.CreateTheme in each of the samples instead of defaulting
to the dark theme.

BUG=#128