### PR TITLE
Disable AssertUIGoroutine on js architecture.

### DIFF
--- a/drivers/gl/debug.go
+++ b/drivers/gl/debug.go
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// +build !js
+
 package gl
 
 import (

--- a/drivers/gl/debug_js.go
+++ b/drivers/gl/debug_js.go
@@ -1,0 +1,15 @@
+// Copyright 2015 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build js
+
+package gl
+
+func (d *driver) discoverUIGoRoutine() {
+	println("discoverUIGoRoutine not yet implemented on js architecture")
+}
+
+func (d *driver) AssertUIGoroutine() {
+	// AssertUIGoroutine not yet implemented on js architecture, so it never panics.
+}


### PR DESCRIPTION
It is not currently supported, as runtime package is not fully supported. This allows it to work as is.

Followup to #133.

In the web, there is only one real thread, and WebGL is safe to call from that single thread. So I don't think the ui goroutine requirement applies to web platform at this time anyway.