### PR TITLE
Add recreateControls flag to the OnDataChanged list/tree event.

### DIFF
--- a/adapter_base.go
+++ b/adapter_base.go
@@ -8,9 +8,9 @@ type AdapterBase struct {
 	onDataChanged, onDataReplaced Event
 }
 
-func (a *AdapterBase) DataChanged() {
+func (a *AdapterBase) DataChanged(recreateControls bool) {
 	if a.onDataChanged != nil {
-		a.onDataChanged.Fire()
+		a.onDataChanged.Fire(recreateControls)
 	}
 }
 
@@ -20,9 +20,9 @@ func (a *AdapterBase) DataReplaced() {
 	}
 }
 
-func (a *AdapterBase) OnDataChanged(f func()) EventSubscription {
+func (a *AdapterBase) OnDataChanged(f func(recreateControls bool)) EventSubscription {
 	if a.onDataChanged == nil {
-		a.onDataChanged = CreateEvent(func() {})
+		a.onDataChanged = CreateEvent(func(bool) {})
 	}
 	return a.onDataChanged.Listen(f)
 }

--- a/default_adapter.go
+++ b/default_adapter.go
@@ -58,7 +58,7 @@ func (a *DefaultAdapter) SetSizeAsLargest(theme Theme) {
 
 func (a *DefaultAdapter) SetStyleLabel(f func(Theme, Label)) {
 	a.styleLabel = f
-	a.DataChanged()
+	a.DataChanged(true)
 }
 
 func (a *DefaultAdapter) Count() int {
@@ -102,7 +102,7 @@ func (a *DefaultAdapter) Size(theme Theme) math.Size {
 
 func (a *DefaultAdapter) SetSize(s math.Size) {
 	a.size = s
-	a.DataChanged()
+	a.DataChanged(true)
 }
 
 func (a *DefaultAdapter) Create(theme Theme, index int) Control {

--- a/list.go
+++ b/list.go
@@ -52,8 +52,11 @@ type ListAdapter interface {
 	Size(Theme) math.Size
 
 	// OnDataChanged registers f to be called when there is a partial change in
-	// the items of the adapter.
-	OnDataChanged(f func()) EventSubscription
+	// the items of the adapter. Scroll positions and selections should be
+	// preserved if possible.
+	// If recreateControls is true then each of the visible controls should be
+	// recreated by re-calling Create().
+	OnDataChanged(f func(recreateControls bool)) EventSubscription
 
 	// OnDataReplaced registers f to be called when there is a complete
 	// replacement of items in the adapter.

--- a/mixins/drop_down_list.go
+++ b/mixins/drop_down_list.go
@@ -160,7 +160,7 @@ func (l *DropDownList) SetAdapter(adapter gxui.ListAdapter) {
 	if l.list.Adapter() != adapter {
 		l.list.SetAdapter(adapter)
 		if adapter != nil {
-			adapter.OnDataChanged(l.DataReplaced)
+			adapter.OnDataChanged(func(bool) { l.DataReplaced() })
 			adapter.OnDataReplaced(l.DataReplaced)
 		}
 		// TODO: Unlisten

--- a/mixins/list.go
+++ b/mixins/list.go
@@ -280,19 +280,21 @@ func (l *List) SizeChanged() {
 	l.outer.Relayout()
 }
 
-func (l *List) DataChanged() {
+func (l *List) DataChanged(recreateControls bool) {
+	if recreateControls {
+		for item, details := range l.details {
+			details.onClickSubscription.Unlisten()
+			l.RemoveChild(details.child.Control)
+			delete(l.details, item)
+		}
+	}
 	l.itemCount = l.adapter.Count()
 	l.SizeChanged()
 }
 
 func (l *List) DataReplaced() {
 	l.selectedItem = nil
-	for item, details := range l.details {
-		details.onClickSubscription.Unlisten()
-		l.RemoveChild(details.child.Control)
-		delete(l.details, item)
-	}
-	l.DataChanged()
+	l.DataChanged(true)
 }
 
 func (l *List) Paint(c gxui.Canvas) {

--- a/mixins/textbox.go
+++ b/mixins/textbox.go
@@ -5,10 +5,11 @@
 package mixins
 
 import (
+	"strings"
+
 	"github.com/google/gxui"
 	"github.com/google/gxui/math"
 	"github.com/google/gxui/mixins/parts"
-	"strings"
 )
 
 type TextBoxLine interface {
@@ -77,7 +78,7 @@ func (t *TextBox) Init(outer TextBoxOuter, driver gxui.Driver, theme gxui.Theme,
 	t.OnLostFocus(func() { t.onRedrawLines.Fire() })
 	t.controller.OnTextChanged(func([]gxui.TextBoxEdit) {
 		t.onRedrawLines.Fire()
-		t.List.DataChanged()
+		t.List.DataChanged(false)
 	})
 	t.controller.OnSelectionChanged(func() {
 		t.onRedrawLines.Fire()

--- a/mixins/tree_to_list_adapter.go
+++ b/mixins/tree_to_list_adapter.go
@@ -42,9 +42,9 @@ func CreateTreeToListAdapter(treeAdapter gxui.TreeAdapter, creator TreeControlCr
 		listAdapter.reset()
 		listAdapter.DataReplaced()
 	})
-	treeAdapter.OnDataChanged(func() {
+	treeAdapter.OnDataChanged(func(recreateControls bool) {
 		listAdapter.node.update(listAdapter)
-		listAdapter.DataChanged()
+		listAdapter.DataChanged(recreateControls)
 	})
 	listAdapter.reset()
 	return listAdapter
@@ -53,7 +53,7 @@ func CreateTreeToListAdapter(treeAdapter gxui.TreeAdapter, creator TreeControlCr
 func (a *TreeToListAdapter) adjustDescendants(delta int) {
 	if delta != 0 {
 		a.node.descendants += delta
-		a.DataChanged()
+		a.DataChanged(false)
 	}
 }
 

--- a/mixins/tree_to_list_node.go
+++ b/mixins/tree_to_list_node.go
@@ -45,6 +45,7 @@ func (n *TreeToListNode) update(nAsParent treeToListNodeParent) {
 			node := n.container.NodeAt(i)
 			item := node.Item()
 			if p, ok := m[item]; ok {
+				p.container = node
 				p.update(p)
 				n.children[i] = p
 				n.descendants += p.descendants + 1

--- a/mixins/tree_to_list_test.go
+++ b/mixins/tree_to_list_test.go
@@ -143,7 +143,7 @@ func TestTreeToListNodeDeep(t *testing.T) {
 		gxui.AdapterItem(142), // (6)       ╚══ 142
 	)
 
-	tree_adapter.DataChanged()
+	tree_adapter.DataChanged(false)
 	test(t, "data-changed", list_adapter,
 		gxui.AdapterItem(100), // (0) 100
 		gxui.AdapterItem(110), // (1)  ╠══ 110

--- a/samples/file_dlg/main.go
+++ b/samples/file_dlg/main.go
@@ -47,7 +47,7 @@ type filesAdapter struct {
 // SetFiles assigns the specified list of absolute-path files to this adapter.
 func (a *filesAdapter) SetFiles(files []string) {
 	a.files = files
-	a.DataChanged()
+	a.DataChanged(false)
 }
 
 func (a *filesAdapter) Count() int {

--- a/samples/tree/main.go
+++ b/samples/tree/main.go
@@ -170,7 +170,7 @@ func appMain(driver gxui.Driver) {
 	adapter := &adapter{}
 
 	// hook up node changed function to the adapter OnDataChanged event.
-	adapter.changed = adapter.DataChanged
+	adapter.changed = func() { adapter.DataChanged(false) }
 
 	// add all the species to the 'Animals' root node.
 	items := addSpecies(adapter.add("Animals"))

--- a/tree.go
+++ b/tree.go
@@ -81,8 +81,11 @@ type TreeAdapter interface {
 	Size(Theme) math.Size
 
 	// OnDataChanged registers f to be called when there is a partial change in
-	// the items of the adapter.
-	OnDataChanged(f func()) EventSubscription
+	// the items of the adapter. Scroll positions and selections should be
+	// preserved if possible.
+	// If recreateControls is true then each of the visible controls should be
+	// recreated by re-calling Create().
+	OnDataChanged(f func(recreateControls bool)) EventSubscription
 
 	// OnDataReplaced registers f to be called when there is a complete
 	// replacement of items in the adapter.


### PR DESCRIPTION
This allows the adapter to indicate that there was UI changes for existing elements, while keeping selection and scroll position.