### PR TITLE
Add package summary for drivers/gl package.

### DIFF
--- a/drivers/gl/driver.go
+++ b/drivers/gl/driver.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Package gl contains an OpenGL implementation of the gxui.Driver interface.
 package gl
 
 import (
@@ -34,6 +35,7 @@ type driver struct {
 	uiPC uintptr   // the program-counter of the applicationLoop function.
 }
 
+// StartDriver starts the gl driver with the given appRoutine.
 func StartDriver(appRoutine func(driver gxui.Driver)) {
 	if runtime.GOMAXPROCS(-1) < 2 {
 		runtime.GOMAXPROCS(2)
@@ -124,9 +126,8 @@ func (d *driver) CallSync(f func()) bool {
 	if d.Call(func() { f(); close(c) }) {
 		<-c
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 func (d *driver) Terminate() {

--- a/drivers/gl/polygon.go
+++ b/drivers/gl/polygon.go
@@ -212,7 +212,6 @@ func openPolyToShape(p gxui.Polygon, penWidth float32) *shape {
 		return newShape(newVertexBuffer(
 			newVertexStream("aPosition", stFloatVec2, vsEdgePos),
 		), nil, dmTriangleStrip)
-	} else {
-		return nil
 	}
+	return nil
 }

--- a/drivers/gl/viewport.go
+++ b/drivers/gl/viewport.go
@@ -18,9 +18,9 @@ import (
 
 const viewportDebugEnabled = false
 
-const kClearColorR = 0.5
-const kClearColorG = 0.5
-const kClearColorB = 0.5
+const clearColorR = 0.5
+const clearColorG = 0.5
+const clearColorB = 0.5
 
 type viewport struct {
 	sync.Mutex
@@ -114,7 +114,7 @@ func newViewport(driver *driver, width, height int, title string, fullscreen boo
 		v.sizePixels = math.Size{W: w, H: h}
 		v.Unlock()
 		gl.Viewport(0, 0, w, h)
-		gl.ClearColor(kClearColorR, kClearColorG, kClearColorB, 1.0)
+		gl.ClearColor(clearColorR, clearColorG, clearColorB, 1.0)
 		gl.Clear(gl.COLOR_BUFFER_BIT)
 	})
 	wnd.SetCursorPosCallback(func(w *glfw.Window, x, y float64) {
@@ -233,7 +233,7 @@ func newViewport(driver *driver, width, height int, title string, fullscreen boo
 	gl.Enable(gl.SCISSOR_TEST)
 	gl.Viewport(0, 0, fw, fh)
 	gl.Scissor(0, 0, int32(fw), int32(fh))
-	gl.ClearColor(kClearColorR, kClearColorG, kClearColorB, 1.0)
+	gl.ClearColor(clearColorR, clearColorG, clearColorB, 1.0)
 	gl.Clear(gl.COLOR_BUFFER_BIT)
 	wnd.SwapBuffers()
 


### PR DESCRIPTION
Also, fix minor golint issues inside the package:

	$ golint drivers/gl
	drivers/gl/driver.go:37:1: exported function StartDriver should have comment or be unexported
	drivers/gl/driver.go:127:9: if block ends with a return statement, so drop this else and outdent its block
	drivers/gl/polygon.go:215:9: if block ends with a return statement, so drop this else and outdent its block
	drivers/gl/viewport.go:21:7: don't use leading k in Go names; const kClearColorR should be clearColorR
	drivers/gl/viewport.go:22:7: don't use leading k in Go names; const kClearColorG should be clearColorG
	drivers/gl/viewport.go:23:7: don't use leading k in Go names; const kClearColorB should be clearColorB